### PR TITLE
Compile chtl code with java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.chtl</groupId>
+    <artifactId>chtl-compiler</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>CHTL Compiler</name>
+    <description>CHTL语言编译器实现</description>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <antlr4.version>4.13.1</antlr4.version>
+        <junit.version>5.10.0</junit.version>
+        <slf4j.version>2.0.9</slf4j.version>
+        <logback.version>1.4.11</logback.version>
+    </properties>
+
+    <dependencies>
+        <!-- ANTLR Runtime -->
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
+            <version>${antlr4.version}</version>
+        </dependency>
+
+        <!-- 日志框架 -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+        </dependency>
+
+        <!-- 测试依赖 -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+
+            <!-- ANTLR Maven Plugin -->
+            <plugin>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-maven-plugin</artifactId>
+                <version>${antlr4.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>antlr4</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <sourceDirectory>src/main/antlr4</sourceDirectory>
+                    <outputDirectory>src/main/java</outputDirectory>
+                    <visitor>true</visitor>
+                    <listener>true</listener>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/antlr4/com/chtl/css/CSS3.g4
+++ b/src/main/antlr4/com/chtl/css/CSS3.g4
@@ -1,0 +1,412 @@
+grammar CSS3;
+
+// Parser Rules
+stylesheet
+    : ws? charsetRule? (importRule ws?)* (namespaceRule ws?)* (cdoCdc ws? | statement ws?)* EOF
+    ;
+
+charsetRule
+    : '@charset' ws? STRING ws? ';'
+    ;
+
+importRule
+    : '@import' ws? (STRING | url) ws? mediaQueryList? ';'
+    ;
+
+namespaceRule
+    : '@namespace' ws? (namespacePrefix ws?)? (STRING | url) ws? ';'
+    ;
+
+namespacePrefix
+    : IDENT
+    ;
+
+mediaQueryList
+    : ws? mediaQuery (ws? ',' ws? mediaQuery)*
+    ;
+
+mediaQuery
+    : (ONLY | NOT)? ws? mediaType ws? (AND ws? mediaExpression)*
+    | mediaExpression (ws? AND ws? mediaExpression)*
+    ;
+
+mediaType
+    : IDENT
+    ;
+
+mediaExpression
+    : '(' ws? mediaFeature ws? (':' ws? expr)? ws? ')'
+    ;
+
+mediaFeature
+    : IDENT
+    ;
+
+statement
+    : ruleset
+    | media
+    | page
+    | fontFace
+    | keyframes
+    | supports
+    | viewport
+    | counterStyle
+    | fontFeatureValues
+    | unknownRule
+    ;
+
+ruleset
+    : selectors ws? '{' ws? declarationList? '}' ws?
+    ;
+
+selectors
+    : selector (ws? ',' ws? selector)*
+    ;
+
+selector
+    : simpleSelectorSequence ws? (combinator simpleSelectorSequence ws?)*
+    ;
+
+combinator
+    : ws? ('+' | '>' | '~' | '//')  // // is for deep combinator
+    | ws  // descendant combinator
+    ;
+
+simpleSelectorSequence
+    : (typeSelector | universal) (HASH | classSelector | attrib | pseudo | negation)*
+    | (HASH | classSelector | attrib | pseudo | negation)+
+    ;
+
+typeSelector
+    : typeNamespacePrefix? elementName
+    ;
+
+typeNamespacePrefix
+    : (namespacePrefix | '*')? '|'
+    ;
+
+elementName
+    : IDENT
+    ;
+
+universal
+    : typeNamespacePrefix? '*'
+    ;
+
+classSelector
+    : '.' IDENT
+    ;
+
+attrib
+    : '[' ws? typeNamespacePrefix? IDENT ws? (attribOperator ws? (IDENT | STRING) ws?)? ']'
+    ;
+
+attribOperator
+    : '=' | '~=' | '|=' | '^=' | '$=' | '*='
+    ;
+
+pseudo
+    : ':' ':'? (IDENT | functionalPseudo)
+    ;
+
+functionalPseudo
+    : FUNCTION ws? expression ')'
+    ;
+
+expression
+    : (term ws?)+
+    ;
+
+negation
+    : ':not(' ws? negationArg ws? ')'
+    ;
+
+negationArg
+    : typeSelector | universal | HASH | classSelector | attrib | pseudo
+    ;
+
+declarationList
+    : (declaration ';' ws?)* declaration?
+    ;
+
+declaration
+    : property ws? ':' ws? expr important?
+    ;
+
+property
+    : IDENT
+    ;
+
+important
+    : ws? '!' ws? 'important'
+    ;
+
+expr
+    : term (operator? term)*
+    ;
+
+term
+    : unaryOperator? (NUMBER | PERCENTAGE | LENGTH | EMS | EXS | ANGLE | TIME | FREQ | RESOLUTION)
+    | STRING | IDENT | url | HASH | UNICODE_RANGE | INCLUDES | DASHMATCH
+    | ':' IDENT  // for IE filter
+    | FUNCTION ws? expr ')'
+    ;
+
+operator
+    : '/' | ',' | ws
+    ;
+
+unaryOperator
+    : '+' | '-'
+    ;
+
+url
+    : 'url(' ws? (STRING | URL) ws? ')'
+    ;
+
+// Media rules
+media
+    : '@media' mediaQueryList '{' ws? groupRuleBody '}' ws?
+    ;
+
+// Page rules
+page
+    : '@page' ws? pseudoPage? '{' ws? declarationList? '}' ws?
+    ;
+
+pseudoPage
+    : ':' IDENT
+    ;
+
+// Font face rules
+fontFace
+    : '@font-face' ws? '{' ws? declarationList? '}' ws?
+    ;
+
+// Keyframes rules
+keyframes
+    : '@' KEYFRAMES ws? IDENT ws? '{' ws? keyframesBlocks '}' ws?
+    ;
+
+keyframesBlocks
+    : keyframeSelector ws? '{' ws? declarationList? '}' ws? (keyframeSelector ws? '{' ws? declarationList? '}' ws?)*
+    ;
+
+keyframeSelector
+    : (FROM | TO | PERCENTAGE) (ws? ',' ws? (FROM | TO | PERCENTAGE))*
+    ;
+
+// Supports rules
+supports
+    : '@supports' ws? supportsCondition ws? '{' ws? groupRuleBody '}' ws?
+    ;
+
+supportsCondition
+    : supportsNegation | supportsConjunction | supportsDisjunction | supportsConditionInParens
+    ;
+
+supportsConditionInParens
+    : '(' ws? supportsCondition ws? ')' | supportsDeclarationCondition | generalEnclosed
+    ;
+
+supportsNegation
+    : NOT ws supportsConditionInParens
+    ;
+
+supportsConjunction
+    : supportsConditionInParens (ws AND ws supportsConditionInParens)+
+    ;
+
+supportsDisjunction
+    : supportsConditionInParens (ws OR ws supportsConditionInParens)+
+    ;
+
+supportsDeclarationCondition
+    : '(' ws? declaration ws? ')'
+    ;
+
+generalEnclosed
+    : FUNCTION (any | generalEnclosed)* ')'
+    | '(' (any | generalEnclosed)* ')'
+    ;
+
+any
+    : IDENT | NUMBER | PERCENTAGE | LENGTH | EMS | EXS | ANGLE | TIME | FREQ | RESOLUTION
+    | STRING | URL | HASH | UNICODE_RANGE | INCLUDES | DASHMATCH | ':' | FUNCTION
+    | '(' any* ')' | '[' any* ']' | ws
+    ;
+
+// Viewport rules
+viewport
+    : '@viewport' ws? '{' ws? declarationList? '}' ws?
+    ;
+
+// Counter style rules
+counterStyle
+    : '@counter-style' ws? IDENT ws? '{' ws? declarationList? '}' ws?
+    ;
+
+// Font feature values
+fontFeatureValues
+    : '@font-feature-values' ws? fontFamilyNameList ws? '{' ws? fontFeatureValueBlock* '}' ws?
+    ;
+
+fontFamilyNameList
+    : fontFamilyName (ws? ',' ws? fontFamilyName)*
+    ;
+
+fontFamilyName
+    : STRING | (IDENT ws?)+
+    ;
+
+fontFeatureValueBlock
+    : fontFeatureType ws? '{' ws? fontFeatureValueList? '}' ws?
+    ;
+
+fontFeatureType
+    : '@stylistic' | '@historical-forms' | '@styleset' | '@character-variant'
+    | '@swash' | '@ornaments' | '@annotation'
+    ;
+
+fontFeatureValueList
+    : fontFeatureValue (ws? ';' ws? fontFeatureValue)* ';'?
+    ;
+
+fontFeatureValue
+    : IDENT ws? ':' ws? NUMBER (ws? NUMBER)*
+    ;
+
+// Group rule body
+groupRuleBody
+    : (ruleset | media | page | fontFace | keyframes | supports | viewport 
+      | counterStyle | fontFeatureValues | unknownRule)*
+    ;
+
+// Unknown rules
+unknownRule
+    : unknownAtRule
+    ;
+
+unknownAtRule
+    : '@' IDENT (any | ';' | '{' unknownBlock '}')*
+    ;
+
+unknownBlock
+    : (any | unknownBlock | ';')*
+    ;
+
+// CDO/CDC
+cdoCdc
+    : CDO | CDC
+    ;
+
+// Whitespace
+ws
+    : (COMMENT | WS)+
+    ;
+
+// Lexer Rules
+CDO : '<!--';
+CDC : '-->';
+
+INCLUDES : '~=';
+DASHMATCH : '|=';
+
+FROM : 'from';
+TO : 'to';
+
+KEYFRAMES
+    : '@keyframes'
+    | '@-webkit-keyframes'
+    | '@-moz-keyframes'
+    | '@-o-keyframes'
+    ;
+
+ONLY : 'only';
+NOT : 'not';
+AND : 'and';
+OR : 'or';
+
+HASH : '#' NAME;
+
+STRING
+    : '"' (~["\r\n\\] | '\\' .)* '"'
+    | '\'' (~['\r\n\\] | '\\' .)* '\''
+    ;
+
+NUMBER
+    : [0-9]+ ('.' [0-9]+)?
+    ;
+
+PERCENTAGE : NUMBER '%';
+
+LENGTH
+    : NUMBER ('px' | 'cm' | 'mm' | 'in' | 'pt' | 'pc' | 'ch' | 'rem' | 'vw' | 'vh' | 'vmin' | 'vmax')
+    ;
+
+EMS : NUMBER 'em';
+EXS : NUMBER 'ex';
+
+ANGLE
+    : NUMBER ('deg' | 'rad' | 'grad' | 'turn')
+    ;
+
+TIME
+    : NUMBER ('s' | 'ms')
+    ;
+
+FREQ
+    : NUMBER ('hz' | 'khz')
+    ;
+
+RESOLUTION
+    : NUMBER ('dpi' | 'dpcm' | 'dppx')
+    ;
+
+UNICODE_RANGE
+    : 'u+' [0-9a-fA-F?]+ ('-' [0-9a-fA-F]+)?
+    ;
+
+IDENT
+    : '-'? NMSTART NMCHAR*
+    ;
+
+FUNCTION
+    : IDENT '('
+    ;
+
+URL
+    : (~['")\s])+
+    ;
+
+COMMENT
+    : '/*' .*? '*/' -> skip
+    ;
+
+WS
+    : [ \t\r\n]+ -> skip
+    ;
+
+fragment NMSTART
+    : [a-zA-Z_]
+    | NONASCII
+    | ESCAPE
+    ;
+
+fragment NMCHAR
+    : [a-zA-Z0-9_-]
+    | NONASCII
+    | ESCAPE
+    ;
+
+fragment NONASCII
+    : ~[\u0000-\u007F]
+    ;
+
+fragment ESCAPE
+    : '\\' ([0-9a-fA-F]{1,6} ' '? | ~[\r\n\f0-9a-fA-F])
+    ;
+
+fragment NAME
+    : NMCHAR+
+    ;

--- a/src/main/antlr4/com/chtl/javascript/ECMAScript.g4
+++ b/src/main/antlr4/com/chtl/javascript/ECMAScript.g4
@@ -1,0 +1,573 @@
+grammar ECMAScript;
+
+// Parser Rules
+program
+    : sourceElements? EOF
+    ;
+
+sourceElements
+    : sourceElement+
+    ;
+
+sourceElement
+    : statement
+    | functionDeclaration
+    ;
+
+statement
+    : block
+    | variableStatement
+    | emptyStatement
+    | expressionStatement
+    | ifStatement
+    | iterationStatement
+    | continueStatement
+    | breakStatement
+    | returnStatement
+    | withStatement
+    | labelledStatement
+    | switchStatement
+    | throwStatement
+    | tryStatement
+    | debuggerStatement
+    ;
+
+block
+    : '{' statementList? '}'
+    ;
+
+statementList
+    : statement+
+    ;
+
+variableStatement
+    : varModifier variableDeclarationList eos
+    ;
+
+variableDeclarationList
+    : variableDeclaration (',' variableDeclaration)*
+    ;
+
+variableDeclaration
+    : (Identifier | bindingPattern) ('=' singleExpression)?
+    ;
+
+bindingPattern
+    : '[' (Identifier (',' Identifier)*)? ']'  // Array pattern
+    | '{' (propertyName ':' Identifier (',' propertyName ':' Identifier)*)? '}'  // Object pattern
+    ;
+
+emptyStatement
+    : SemiColon
+    ;
+
+expressionStatement
+    : {notOpenBraceAndNotFunction()}? expressionSequence eos
+    ;
+
+ifStatement
+    : If '(' expressionSequence ')' statement (Else statement)?
+    ;
+
+iterationStatement
+    : Do statement While '(' expressionSequence ')' eos                                                         # DoStatement
+    | While '(' expressionSequence ')' statement                                                                # WhileStatement
+    | For '(' (expressionSequence | variableDeclarationList)? ';' expressionSequence? ';' expressionSequence? ')' statement # ForStatement
+    | For '(' (singleExpression | variableDeclarationList) In expressionSequence ')' statement                  # ForInStatement
+    | For '(' (singleExpression | variableDeclarationList) Of expressionSequence ')' statement                  # ForOfStatement
+    ;
+
+varModifier
+    : Var
+    | Let
+    | Const
+    ;
+
+continueStatement
+    : Continue ({notLineTerminator()}? Identifier)? eos
+    ;
+
+breakStatement
+    : Break ({notLineTerminator()}? Identifier)? eos
+    ;
+
+returnStatement
+    : Return ({notLineTerminator()}? expressionSequence)? eos
+    ;
+
+withStatement
+    : With '(' expressionSequence ')' statement
+    ;
+
+switchStatement
+    : Switch '(' expressionSequence ')' caseBlock
+    ;
+
+caseBlock
+    : '{' caseClauses? (defaultClause caseClauses?)? '}'
+    ;
+
+caseClauses
+    : caseClause+
+    ;
+
+caseClause
+    : Case expressionSequence ':' statementList?
+    ;
+
+defaultClause
+    : Default ':' statementList?
+    ;
+
+labelledStatement
+    : Identifier ':' statement
+    ;
+
+throwStatement
+    : Throw {notLineTerminator()}? expressionSequence eos
+    ;
+
+tryStatement
+    : Try block (catchProduction finallyProduction? | finallyProduction)
+    ;
+
+catchProduction
+    : Catch '(' Identifier ')' block
+    ;
+
+finallyProduction
+    : Finally block
+    ;
+
+debuggerStatement
+    : Debugger eos
+    ;
+
+functionDeclaration
+    : Function Identifier '(' formalParameterList? ')' '{' functionBody '}'
+    ;
+
+formalParameterList
+    : formalParameterArg (',' formalParameterArg)*
+    ;
+
+formalParameterArg
+    : Identifier ('=' singleExpression)?
+    ;
+
+functionBody
+    : sourceElements?
+    ;
+
+expressionSequence
+    : singleExpression (',' singleExpression)*
+    ;
+
+singleExpression
+    : Function Identifier? '(' formalParameterList? ')' '{' functionBody '}'                       # FunctionExpression
+    | singleExpression '[' expressionSequence ']'                                                  # MemberIndexExpression
+    | singleExpression '.' identifierName                                                          # MemberDotExpression
+    | singleExpression arguments                                                                   # ArgumentsExpression
+    | New singleExpression                                                                         # NewExpression
+    | singleExpression {notLineTerminator()}? '++'                                                 # PostIncrementExpression
+    | singleExpression {notLineTerminator()}? '--'                                                 # PostDecreaseExpression
+    | Delete singleExpression                                                                      # DeleteExpression
+    | Void singleExpression                                                                        # VoidExpression
+    | Typeof singleExpression                                                                      # TypeofExpression
+    | '++' singleExpression                                                                        # PreIncrementExpression
+    | '--' singleExpression                                                                        # PreDecreaseExpression
+    | '+' singleExpression                                                                         # UnaryPlusExpression
+    | '-' singleExpression                                                                         # UnaryMinusExpression
+    | '~' singleExpression                                                                         # BitNotExpression
+    | '!' singleExpression                                                                         # NotExpression
+    | <assoc=right> singleExpression '**' singleExpression                                         # PowerExpression
+    | singleExpression ('*' | '/' | '%') singleExpression                                         # MultiplicativeExpression
+    | singleExpression ('+' | '-') singleExpression                                               # AdditiveExpression
+    | singleExpression ('<<' | '>>' | '>>>') singleExpression                                     # BitShiftExpression
+    | singleExpression ('<' | '>' | '<=' | '>=') singleExpression                                 # RelationalExpression
+    | singleExpression Instanceof singleExpression                                                 # InstanceofExpression
+    | singleExpression In singleExpression                                                         # InExpression
+    | singleExpression ('==' | '!=' | '===' | '!==') singleExpression                            # EqualityExpression
+    | singleExpression '&' singleExpression                                                        # BitAndExpression
+    | singleExpression '^' singleExpression                                                        # BitXOrExpression
+    | singleExpression '|' singleExpression                                                        # BitOrExpression
+    | singleExpression '&&' singleExpression                                                       # LogicalAndExpression
+    | singleExpression '||' singleExpression                                                       # LogicalOrExpression
+    | singleExpression '?' singleExpression ':' singleExpression                                   # TernaryExpression
+    | <assoc=right> singleExpression '=' singleExpression                                          # AssignmentExpression
+    | <assoc=right> singleExpression assignmentOperator singleExpression                           # AssignmentOperatorExpression
+    | This                                                                                         # ThisExpression
+    | Identifier                                                                                   # IdentifierExpression
+    | literal                                                                                      # LiteralExpression
+    | arrayLiteral                                                                                 # ArrayLiteralExpression
+    | objectLiteral                                                                                # ObjectLiteralExpression
+    | '(' expressionSequence ')'                                                                   # ParenthesizedExpression
+    | arrowFunctionParameters '=>' arrowFunctionBody                                               # ArrowFunctionExpression
+    ;
+
+assignmentOperator
+    : '*='
+    | '/='
+    | '%='
+    | '+='
+    | '-='
+    | '<<='
+    | '>>='
+    | '>>>='
+    | '&='
+    | '^='
+    | '|='
+    | '**='
+    ;
+
+literal
+    : NullLiteral
+    | BooleanLiteral
+    | StringLiteral
+    | TemplateStringLiteral
+    | RegularExpressionLiteral
+    | numericLiteral
+    ;
+
+numericLiteral
+    : DecimalLiteral
+    | HexIntegerLiteral
+    | OctalIntegerLiteral
+    | OctalIntegerLiteral2
+    | BinaryIntegerLiteral
+    ;
+
+identifierName
+    : Identifier
+    | reservedWord
+    ;
+
+reservedWord
+    : keyword
+    | NullLiteral
+    | BooleanLiteral
+    ;
+
+keyword
+    : Break
+    | Do
+    | Instanceof
+    | Typeof
+    | Case
+    | Else
+    | New
+    | Var
+    | Catch
+    | Finally
+    | Return
+    | Void
+    | Continue
+    | For
+    | Switch
+    | While
+    | Debugger
+    | Function
+    | This
+    | With
+    | Default
+    | If
+    | Throw
+    | Delete
+    | In
+    | Try
+    | Class
+    | Enum
+    | Extends
+    | Super
+    | Const
+    | Export
+    | Import
+    | Implements
+    | Let
+    | Private
+    | Public
+    | Interface
+    | Package
+    | Protected
+    | Static
+    | Yield
+    | Of
+    ;
+
+arguments
+    : '(' argumentList? ')'
+    ;
+
+argumentList
+    : argument (',' argument)*
+    ;
+
+argument
+    : '...'? singleExpression
+    ;
+
+arrayLiteral
+    : '[' elementList? ']'
+    ;
+
+elementList
+    : arrayElement (',' arrayElement)*
+    ;
+
+arrayElement
+    : '...'? singleExpression
+    ;
+
+objectLiteral
+    : '{' (propertyAssignment (',' propertyAssignment)*)? ','? '}'
+    ;
+
+propertyAssignment
+    : propertyName ':' singleExpression                                             # PropertyExpressionAssignment
+    | '[' singleExpression ']' ':' singleExpression                                # ComputedPropertyExpressionAssignment
+    | Function Identifier? '(' formalParameterList? ')' '{' functionBody '}'        # PropertyFunctionAssignment
+    | getter '(' ')' '{' functionBody '}'                                          # PropertyGetter
+    | setter '(' formalParameterArg ')' '{' functionBody '}'                       # PropertySetter
+    | '...' singleExpression                                                        # PropertySpread
+    | Identifier                                                                    # PropertyShorthand
+    ;
+
+propertyName
+    : identifierName
+    | StringLiteral
+    | numericLiteral
+    ;
+
+getter
+    : {p("get")}? Identifier
+    ;
+
+setter
+    : {p("set")}? Identifier
+    ;
+
+arrowFunctionParameters
+    : Identifier
+    | '(' formalParameterList? ')'
+    ;
+
+arrowFunctionBody
+    : singleExpression
+    | '{' functionBody '}'
+    ;
+
+eos
+    : SemiColon
+    | EOF
+    | {lineTerminatorAhead()}?
+    ;
+
+// Lexer Rules
+RegularExpressionLiteral
+    : '/' RegularExpressionFirstChar RegularExpressionChar* '/' IdentifierPart*
+    ;
+
+NullLiteral
+    : 'null'
+    ;
+
+BooleanLiteral
+    : 'true'
+    | 'false'
+    ;
+
+DecimalLiteral
+    : DecimalIntegerLiteral '.' DecimalDigit* ExponentPart?
+    | '.' DecimalDigit+ ExponentPart?
+    | DecimalIntegerLiteral ExponentPart?
+    ;
+
+HexIntegerLiteral
+    : '0' [xX] HexDigit+
+    ;
+
+OctalIntegerLiteral
+    : '0' OctalDigit+
+    ;
+
+OctalIntegerLiteral2
+    : '0' [oO] OctalDigit+
+    ;
+
+BinaryIntegerLiteral
+    : '0' [bB] BinaryDigit+
+    ;
+
+Break : 'break';
+Do : 'do';
+Instanceof : 'instanceof';
+Typeof : 'typeof';
+Case : 'case';
+Else : 'else';
+New : 'new';
+Var : 'var';
+Catch : 'catch';
+Finally : 'finally';
+Return : 'return';
+Void : 'void';
+Continue : 'continue';
+For : 'for';
+Switch : 'switch';
+While : 'while';
+Debugger : 'debugger';
+Function : 'function';
+This : 'this';
+With : 'with';
+Default : 'default';
+If : 'if';
+Throw : 'throw';
+Delete : 'delete';
+In : 'in';
+Try : 'try';
+Class : 'class';
+Enum : 'enum';
+Extends : 'extends';
+Super : 'super';
+Const : 'const';
+Export : 'export';
+Import : 'import';
+Implements : 'implements';
+Let : 'let';
+Private : 'private';
+Public : 'public';
+Interface : 'interface';
+Package : 'package';
+Protected : 'protected';
+Static : 'static';
+Yield : 'yield';
+Of : 'of';
+
+Identifier
+    : IdentifierStart IdentifierPart*
+    ;
+
+StringLiteral
+    : '"' DoubleStringCharacter* '"'
+    | '\'' SingleStringCharacter* '\''
+    ;
+
+TemplateStringLiteral
+    : '`' ('\\`' | ~'`')* '`'
+    ;
+
+WhiteSpaces
+    : [\t\u000B\u000C\u0020\u00A0]+ -> skip
+    ;
+
+LineTerminator
+    : [\r\n\u2028\u2029] -> skip
+    ;
+
+MultiLineComment
+    : '/*' .*? '*/' -> skip
+    ;
+
+SingleLineComment
+    : '//' ~[\r\n\u2028\u2029]* -> skip
+    ;
+
+UnexpectedCharacter
+    : .
+    ;
+
+SemiColon : ';';
+
+// Fragments
+fragment DoubleStringCharacter
+    : ~["\\\r\n]
+    | '\\' EscapeSequence
+    | LineContinuation
+    ;
+
+fragment SingleStringCharacter
+    : ~['\\\r\n]
+    | '\\' EscapeSequence
+    | LineContinuation
+    ;
+
+fragment EscapeSequence
+    : CharacterEscapeSequence
+    | '0'
+    | HexEscapeSequence
+    | UnicodeEscapeSequence
+    ;
+
+fragment CharacterEscapeSequence
+    : SingleEscapeCharacter
+    | NonEscapeCharacter
+    ;
+
+fragment SingleEscapeCharacter
+    : ['"\\bfnrtv]
+    ;
+
+fragment NonEscapeCharacter
+    : ~['"\\bfnrtv0-9xu\r\n]
+    ;
+
+fragment HexEscapeSequence
+    : 'x' HexDigit HexDigit
+    ;
+
+fragment UnicodeEscapeSequence
+    : 'u' HexDigit HexDigit HexDigit HexDigit
+    ;
+
+fragment HexDigit
+    : [0-9a-fA-F]
+    ;
+
+fragment DecimalIntegerLiteral
+    : '0'
+    | [1-9] DecimalDigit*
+    ;
+
+fragment DecimalDigit
+    : [0-9]
+    ;
+
+fragment ExponentPart
+    : [eE] [+-]? DecimalDigit+
+    ;
+
+fragment IdentifierStart
+    : [\p{L}]
+    | [$_]
+    | '\\' UnicodeEscapeSequence
+    ;
+
+fragment IdentifierPart
+    : IdentifierStart
+    | [\p{Mn}]
+    | [\p{Nd}]
+    | [\p{Pc}]
+    | '\u200C'
+    | '\u200D'
+    ;
+
+fragment RegularExpressionFirstChar
+    : ~[*\\/\r\n]
+    | '\\' ~[\r\n]
+    ;
+
+fragment RegularExpressionChar
+    : ~[\\/\r\n]
+    | '\\' ~[\r\n]
+    ;
+
+fragment LineContinuation
+    : '\\' [\r\n\u2028\u2029]
+    ;
+
+fragment OctalDigit
+    : [0-7]
+    ;
+
+fragment BinaryDigit
+    : [01]
+    ;

--- a/src/main/java/com/chtl/CHTLCompilerMain.java
+++ b/src/main/java/com/chtl/CHTLCompilerMain.java
@@ -1,0 +1,183 @@
+package com.chtl;
+
+import com.chtl.compiler.dispatcher.CompilerDispatcher;
+import com.chtl.model.CodeFragment;
+import com.chtl.model.CompilationResult;
+import com.chtl.output.HTMLMerger;
+import com.chtl.scanner.CHTLUnifiedScanner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+/**
+ * CHTL编译器主类
+ * 整合所有组件，提供完整的编译流程
+ */
+public class CHTLCompilerMain {
+    private static final Logger logger = LoggerFactory.getLogger(CHTLCompilerMain.class);
+    
+    private final CHTLUnifiedScanner scanner;
+    private final CompilerDispatcher dispatcher;
+    private final HTMLMerger merger;
+    
+    public CHTLCompilerMain() {
+        this.scanner = new CHTLUnifiedScanner();
+        this.dispatcher = new CompilerDispatcher();
+        this.merger = new HTMLMerger();
+        
+        logger.info("CHTL编译器初始化完成");
+    }
+    
+    /**
+     * 编译CHTL文件
+     * @param inputPath 输入文件路径
+     * @param outputPath 输出文件路径
+     */
+    public void compileFile(String inputPath, String outputPath) throws IOException {
+        logger.info("开始编译文件: {}", inputPath);
+        
+        // 1. 读取源文件
+        String sourceCode = readFile(inputPath);
+        
+        // 2. 编译
+        String result = compile(sourceCode);
+        
+        // 3. 写入结果
+        writeFile(outputPath, result);
+        
+        logger.info("编译完成，输出文件: {}", outputPath);
+    }
+    
+    /**
+     * 编译CHTL源代码
+     * @param sourceCode CHTL源代码
+     * @return 编译后的HTML
+     */
+    public String compile(String sourceCode) {
+        logger.debug("开始编译CHTL源代码");
+        
+        try {
+            // 1. 扫描和切割代码
+            List<CodeFragment> fragments = scanner.scan(sourceCode);
+            logger.info("扫描完成，生成 {} 个代码片段", fragments.size());
+            
+            // 2. 调度编译
+            List<CompilationResult> results = dispatcher.dispatch(fragments);
+            logger.info("编译完成，生成 {} 个编译结果", results.size());
+            
+            // 3. 检查错误
+            checkErrors(results);
+            
+            // 4. 合并结果
+            String html = merger.merge(results);
+            logger.info("合并完成，生成最终HTML");
+            
+            return html;
+            
+        } catch (Exception e) {
+            logger.error("编译失败", e);
+            throw new CompilationException("编译失败: " + e.getMessage(), e);
+        }
+    }
+    
+    /**
+     * 检查编译错误
+     */
+    private void checkErrors(List<CompilationResult> results) {
+        int errorCount = 0;
+        int warningCount = 0;
+        
+        for (CompilationResult result : results) {
+            if (result.hasErrors()) {
+                for (String error : result.getErrors()) {
+                    logger.error("[{}] 错误: {}", result.getSourceType(), error);
+                    errorCount++;
+                }
+            }
+            
+            for (String warning : result.getWarnings()) {
+                logger.warn("[{}] 警告: {}", result.getSourceType(), warning);
+                warningCount++;
+            }
+        }
+        
+        if (errorCount > 0) {
+            throw new CompilationException(
+                String.format("编译失败，共 %d 个错误，%d 个警告", errorCount, warningCount)
+            );
+        }
+        
+        if (warningCount > 0) {
+            logger.info("编译成功，但有 {} 个警告", warningCount);
+        }
+    }
+    
+    /**
+     * 读取文件
+     */
+    private String readFile(String path) throws IOException {
+        return Files.readString(Paths.get(path));
+    }
+    
+    /**
+     * 写入文件
+     */
+    private void writeFile(String path, String content) throws IOException {
+        Path outputPath = Paths.get(path);
+        Files.createDirectories(outputPath.getParent());
+        Files.writeString(outputPath, content);
+    }
+    
+    /**
+     * 关闭编译器
+     */
+    public void shutdown() {
+        dispatcher.shutdown();
+        logger.info("CHTL编译器已关闭");
+    }
+    
+    /**
+     * 主方法 - 命令行入口
+     */
+    public static void main(String[] args) {
+        if (args.length < 2) {
+            System.out.println("用法: java -jar chtl-compiler.jar <输入文件> <输出文件>");
+            System.out.println("示例: java -jar chtl-compiler.jar index.chtl index.html");
+            System.exit(1);
+        }
+        
+        String inputFile = args[0];
+        String outputFile = args[1];
+        
+        CHTLCompilerMain compiler = new CHTLCompilerMain();
+        
+        try {
+            compiler.compileFile(inputFile, outputFile);
+            System.out.println("编译成功！");
+        } catch (Exception e) {
+            System.err.println("编译失败: " + e.getMessage());
+            e.printStackTrace();
+            System.exit(1);
+        } finally {
+            compiler.shutdown();
+        }
+    }
+    
+    /**
+     * 编译异常
+     */
+    public static class CompilationException extends RuntimeException {
+        public CompilationException(String message) {
+            super(message);
+        }
+        
+        public CompilationException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/src/main/java/com/chtl/compiler/chtl/CHTLCodeGenerator.java
+++ b/src/main/java/com/chtl/compiler/chtl/CHTLCodeGenerator.java
@@ -1,0 +1,279 @@
+package com.chtl.compiler.chtl;
+
+import com.chtl.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * CHTL代码生成器
+ * 负责将AST转换为HTML代码
+ */
+public class CHTLCodeGenerator implements CHTLNodeVisitor {
+    private static final Logger logger = LoggerFactory.getLogger(CHTLCodeGenerator.class);
+    
+    private StringBuilder htmlBuilder;
+    private StringBuilder cssBuilder;
+    private StringBuilder jsBuilder;
+    private int indentLevel;
+    
+    public CHTLCodeGenerator() {
+        this.htmlBuilder = new StringBuilder();
+        this.cssBuilder = new StringBuilder();
+        this.jsBuilder = new StringBuilder();
+        this.indentLevel = 0;
+    }
+    
+    /**
+     * 生成HTML代码
+     */
+    public String generate(CHTLNode ast) {
+        logger.debug("开始生成HTML代码");
+        
+        // 重置构建器
+        htmlBuilder.setLength(0);
+        cssBuilder.setLength(0);
+        jsBuilder.setLength(0);
+        indentLevel = 0;
+        
+        // 遍历AST生成代码
+        ast.accept(this);
+        
+        return htmlBuilder.toString();
+    }
+    
+    /**
+     * 获取生成的CSS代码
+     */
+    public String getGeneratedCSS() {
+        return cssBuilder.toString();
+    }
+    
+    /**
+     * 获取生成的JS代码
+     */
+    public String getGeneratedJS() {
+        return jsBuilder.toString();
+    }
+    
+    @Override
+    public void visit(ElementNode node) {
+        // 跳过根节点
+        if ("root".equals(node.getName())) {
+            for (CHTLNode child : node.getChildren()) {
+                child.accept(this);
+            }
+            return;
+        }
+        
+        // 生成开始标签
+        appendIndent();
+        htmlBuilder.append("<").append(node.getName());
+        
+        // 生成属性
+        for (Map.Entry<String, String> attr : node.getAttributes().entrySet()) {
+            htmlBuilder.append(" ")
+                      .append(attr.getKey())
+                      .append("=\"")
+                      .append(escapeHtml(attr.getValue()))
+                      .append("\"");
+        }
+        
+        // 检查是否是自闭合标签
+        if (isSelfClosingTag(node.getName()) && node.getChildren().isEmpty()) {
+            htmlBuilder.append(" />\n");
+        } else {
+            htmlBuilder.append(">");
+            
+            // 如果有子节点，换行并增加缩进
+            if (!node.getChildren().isEmpty()) {
+                htmlBuilder.append("\n");
+                indentLevel++;
+                
+                for (CHTLNode child : node.getChildren()) {
+                    child.accept(this);
+                }
+                
+                indentLevel--;
+                appendIndent();
+            }
+            
+            // 生成结束标签
+            htmlBuilder.append("</").append(node.getName()).append(">\n");
+        }
+    }
+    
+    @Override
+    public void visit(TextNode node) {
+        String content = node.getContent().trim();
+        if (!content.isEmpty()) {
+            appendIndent();
+            htmlBuilder.append(escapeHtml(content)).append("\n");
+        }
+    }
+    
+    @Override
+    public void visit(AttributeNode node) {
+        // 属性已在ElementNode中处理
+    }
+    
+    @Override
+    public void visit(StyleNode node) {
+        if (node.isLocal()) {
+            // 局部样式需要特殊处理
+            processLocalStyle(node);
+        } else {
+            // 全局样式直接添加到CSS构建器
+            for (StyleNode.StyleRule rule : node.getRules()) {
+                cssBuilder.append(rule.getSelector()).append(" {\n");
+                for (StyleNode.StyleProperty prop : rule.getProperties()) {
+                    cssBuilder.append("  ")
+                             .append(prop.getName())
+                             .append(": ")
+                             .append(prop.getValue())
+                             .append(";\n");
+                }
+                cssBuilder.append("}\n\n");
+            }
+        }
+    }
+    
+    @Override
+    public void visit(ScriptNode node) {
+        if (node.isLocal()) {
+            // 局部脚本添加到JS构建器
+            jsBuilder.append("// Local script\n");
+            jsBuilder.append("(function() {\n");
+            jsBuilder.append(node.getContent());
+            jsBuilder.append("\n})();\n\n");
+        } else {
+            // 全局脚本
+            appendIndent();
+            htmlBuilder.append("<script>\n");
+            indentLevel++;
+            appendIndent();
+            htmlBuilder.append(node.getContent());
+            htmlBuilder.append("\n");
+            indentLevel--;
+            appendIndent();
+            htmlBuilder.append("</script>\n");
+        }
+    }
+    
+    @Override
+    public void visit(TemplateNode node) {
+        // 模板在预处理阶段已经展开，这里不应该再遇到
+        logger.warn("遇到未展开的模板节点: {}", node.getTemplateName());
+    }
+    
+    @Override
+    public void visit(CustomNode node) {
+        // 自定义在预处理阶段已经展开，这里不应该再遇到
+        logger.warn("遇到未展开的自定义节点: {}", node.getCustomName());
+    }
+    
+    /**
+     * 处理局部样式
+     */
+    private void processLocalStyle(StyleNode node) {
+        // 为包含局部样式的元素生成唯一类名
+        String uniqueClass = "chtl-" + UUID.randomUUID().toString().substring(0, 8);
+        
+        // 获取父元素并添加类名
+        CHTLNode parent = node.getParent();
+        if (parent instanceof ElementNode) {
+            ElementNode element = (ElementNode) parent;
+            String existingClass = element.getAttribute("class");
+            if (existingClass != null && !existingClass.isEmpty()) {
+                element.setAttribute("class", existingClass + " " + uniqueClass);
+            } else {
+                element.setAttribute("class", uniqueClass);
+            }
+        }
+        
+        // 处理样式规则
+        for (StyleNode.StyleRule rule : node.getRules()) {
+            if ("inline".equals(rule.getSelector())) {
+                // 内联样式
+                if (parent instanceof ElementNode) {
+                    ElementNode element = (ElementNode) parent;
+                    StringBuilder styleAttr = new StringBuilder();
+                    
+                    for (StyleNode.StyleProperty prop : rule.getProperties()) {
+                        if (!"_raw".equals(prop.getName())) {
+                            styleAttr.append(prop.getName())
+                                    .append(": ")
+                                    .append(prop.getValue())
+                                    .append("; ");
+                        }
+                    }
+                    
+                    String existingStyle = element.getAttribute("style");
+                    if (existingStyle != null && !existingStyle.isEmpty()) {
+                        element.setAttribute("style", existingStyle + " " + styleAttr.toString());
+                    } else {
+                        element.setAttribute("style", styleAttr.toString());
+                    }
+                }
+            } else {
+                // 其他选择器添加到全局CSS
+                String selector = rule.getSelector();
+                if (selector.startsWith(".") || selector.startsWith("#")) {
+                    // 类选择器或ID选择器
+                    cssBuilder.append(selector).append(" {\n");
+                } else if (selector.startsWith("&")) {
+                    // 上下文推导选择器
+                    selector = selector.replace("&", "." + uniqueClass);
+                    cssBuilder.append(selector).append(" {\n");
+                } else {
+                    // 其他选择器，作用域限定
+                    cssBuilder.append(".").append(uniqueClass).append(" ").append(selector).append(" {\n");
+                }
+                
+                for (StyleNode.StyleProperty prop : rule.getProperties()) {
+                    cssBuilder.append("  ")
+                             .append(prop.getName())
+                             .append(": ")
+                             .append(prop.getValue())
+                             .append(";\n");
+                }
+                cssBuilder.append("}\n\n");
+            }
+        }
+    }
+    
+    /**
+     * 添加缩进
+     */
+    private void appendIndent() {
+        for (int i = 0; i < indentLevel; i++) {
+            htmlBuilder.append("  ");
+        }
+    }
+    
+    /**
+     * 转义HTML特殊字符
+     */
+    private String escapeHtml(String text) {
+        return text.replace("&", "&amp;")
+                   .replace("<", "&lt;")
+                   .replace(">", "&gt;")
+                   .replace("\"", "&quot;")
+                   .replace("'", "&#39;");
+    }
+    
+    /**
+     * 检查是否是自闭合标签
+     */
+    private boolean isSelfClosingTag(String tagName) {
+        return "area".equals(tagName) || "base".equals(tagName) || 
+               "br".equals(tagName) || "col".equals(tagName) || 
+               "embed".equals(tagName) || "hr".equals(tagName) || 
+               "img".equals(tagName) || "input".equals(tagName) || 
+               "link".equals(tagName) || "meta".equals(tagName) || 
+               "param".equals(tagName) || "source".equals(tagName) || 
+               "track".equals(tagName) || "wbr".equals(tagName);
+    }
+}

--- a/src/main/java/com/chtl/compiler/chtl/CHTLCompiler.java
+++ b/src/main/java/com/chtl/compiler/chtl/CHTLCompiler.java
@@ -1,0 +1,149 @@
+package com.chtl.compiler.chtl;
+
+import com.chtl.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+/**
+ * CHTL编译器 - 手写实现
+ * 负责编译CHTL主体代码和局部样式
+ */
+public class CHTLCompiler {
+    private static final Logger logger = LoggerFactory.getLogger(CHTLCompiler.class);
+    
+    private final CHTLParser parser;
+    private final CHTLCodeGenerator codeGenerator;
+    private final LocalStyleProcessor localStyleProcessor;
+    
+    // 存储模板和自定义定义
+    private final Map<String, TemplateNode> templates;
+    private final Map<String, CustomNode> customs;
+    
+    public CHTLCompiler() {
+        this.parser = new CHTLParser();
+        this.codeGenerator = new CHTLCodeGenerator();
+        this.localStyleProcessor = new LocalStyleProcessor();
+        this.templates = new HashMap<>();
+        this.customs = new HashMap<>();
+        
+        logger.info("CHTL编译器初始化完成");
+    }
+    
+    /**
+     * 编译CHTL代码片段
+     */
+    public CompilationResult compile(CodeFragment fragment) {
+        logger.debug("开始编译CHTL代码片段");
+        
+        try {
+            // 1. 解析CHTL代码生成AST
+            CHTLNode ast = parser.parse(fragment.getContent());
+            
+            // 2. 收集模板和自定义定义
+            collectDefinitions(ast);
+            
+            // 3. 处理模板展开和继承
+            processTemplates(ast);
+            
+            // 4. 生成HTML代码
+            String html = codeGenerator.generate(ast);
+            
+            // 5. 提取生成的CSS和JS
+            CompilationResult result = new CompilationResult(FragmentType.CHTL, html);
+            result.setGeneratedCSS(codeGenerator.getGeneratedCSS());
+            result.setGeneratedJS(codeGenerator.getGeneratedJS());
+            
+            logger.debug("CHTL编译成功");
+            return result;
+            
+        } catch (Exception e) {
+            logger.error("CHTL编译失败", e);
+            return new CompilationResult(FragmentType.CHTL, "", e.getMessage());
+        }
+    }
+    
+    /**
+     * 编译局部样式
+     */
+    public CompilationResult compileLocalStyle(CodeFragment fragment) {
+        logger.debug("开始编译局部样式");
+        
+        try {
+            LocalStyleResult result = localStyleProcessor.process(fragment.getContent());
+            
+            CompilationResult compilationResult = new CompilationResult(
+                FragmentType.CHTL_LOCAL_STYLE, 
+                result.getInlineStyles()
+            );
+            compilationResult.setGeneratedCSS(result.getGlobalStyles());
+            
+            return compilationResult;
+            
+        } catch (Exception e) {
+            logger.error("局部样式编译失败", e);
+            return new CompilationResult(FragmentType.CHTL_LOCAL_STYLE, "", e.getMessage());
+        }
+    }
+    
+    /**
+     * 收集模板和自定义定义
+     */
+    private void collectDefinitions(CHTLNode root) {
+        DefinitionCollector collector = new DefinitionCollector();
+        root.accept(collector);
+    }
+    
+    /**
+     * 处理模板展开和继承
+     */
+    private void processTemplates(CHTLNode root) {
+        TemplateProcessor processor = new TemplateProcessor(templates, customs);
+        processor.process(root);
+    }
+    
+    /**
+     * 定义收集器 - 内部访问者类
+     */
+    private class DefinitionCollector implements CHTLNodeVisitor {
+        @Override
+        public void visit(ElementNode node) {
+            for (CHTLNode child : node.getChildren()) {
+                child.accept(this);
+            }
+        }
+        
+        @Override
+        public void visit(TextNode node) {
+            // 文本节点无需处理
+        }
+        
+        @Override
+        public void visit(AttributeNode node) {
+            // 属性节点无需处理
+        }
+        
+        @Override
+        public void visit(StyleNode node) {
+            // 样式节点无需处理
+        }
+        
+        @Override
+        public void visit(ScriptNode node) {
+            // 脚本节点无需处理
+        }
+        
+        @Override
+        public void visit(TemplateNode node) {
+            templates.put(node.getTemplateName(), node);
+            logger.debug("收集到模板: {} - {}", node.getType(), node.getTemplateName());
+        }
+        
+        @Override
+        public void visit(CustomNode node) {
+            customs.put(node.getCustomName(), node);
+            logger.debug("收集到自定义: {} - {}", node.getType(), node.getCustomName());
+        }
+    }
+}

--- a/src/main/java/com/chtl/compiler/chtl/CHTLParser.java
+++ b/src/main/java/com/chtl/compiler/chtl/CHTLParser.java
@@ -1,0 +1,581 @@
+package com.chtl.compiler.chtl;
+
+import com.chtl.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * CHTL解析器 - 手写实现
+ * 负责将CHTL代码解析成抽象语法树(AST)
+ */
+public class CHTLParser {
+    private static final Logger logger = LoggerFactory.getLogger(CHTLParser.class);
+    
+    // Token类型
+    private enum TokenType {
+        IDENTIFIER,        // 标识符
+        LEFT_BRACE,       // {
+        RIGHT_BRACE,      // }
+        SEMICOLON,        // ;
+        COLON,            // :
+        EQUALS,           // =
+        STRING,           // 字符串字面量
+        COMMENT,          // 注释
+        KEYWORD_TEXT,     // text关键字
+        KEYWORD_STYLE,    // style关键字
+        KEYWORD_SCRIPT,   // script关键字
+        KEYWORD_TEMPLATE, // [Template]
+        KEYWORD_CUSTOM,   // [Custom]
+        AT_STYLE,         // @Style
+        AT_ELEMENT,       // @Element
+        AT_VAR,           // @Var
+        EOF               // 文件结束
+    }
+    
+    // Token类
+    private static class Token {
+        TokenType type;
+        String value;
+        int line;
+        int column;
+        
+        Token(TokenType type, String value, int line, int column) {
+            this.type = type;
+            this.value = value;
+            this.line = line;
+            this.column = column;
+        }
+    }
+    
+    // 词法分析器
+    private class Lexer {
+        private String input;
+        private int position;
+        private int line;
+        private int column;
+        
+        Lexer(String input) {
+            this.input = input;
+            this.position = 0;
+            this.line = 1;
+            this.column = 1;
+        }
+        
+        Token nextToken() {
+            skipWhitespace();
+            
+            if (position >= input.length()) {
+                return new Token(TokenType.EOF, "", line, column);
+            }
+            
+            // 检查注释
+            if (peek() == '/' && peekNext() == '/') {
+                return readLineComment();
+            }
+            
+            if (peek() == '/' && peekNext() == '*') {
+                return readBlockComment();
+            }
+            
+            // 检查关键字
+            if (peek() == '[') {
+                return readBracketKeyword();
+            }
+            
+            if (peek() == '@') {
+                return readAtKeyword();
+            }
+            
+            // 检查标点符号
+            char ch = peek();
+            switch (ch) {
+                case '{':
+                    advance();
+                    return new Token(TokenType.LEFT_BRACE, "{", line, column - 1);
+                case '}':
+                    advance();
+                    return new Token(TokenType.RIGHT_BRACE, "}", line, column - 1);
+                case ';':
+                    advance();
+                    return new Token(TokenType.SEMICOLON, ";", line, column - 1);
+                case ':':
+                    advance();
+                    return new Token(TokenType.COLON, ":", line, column - 1);
+                case '=':
+                    advance();
+                    return new Token(TokenType.EQUALS, "=", line, column - 1);
+                case '"':
+                case '\'':
+                    return readString();
+            }
+            
+            // 读取标识符或无引号字面量
+            if (isIdentifierStart(ch)) {
+                return readIdentifier();
+            }
+            
+            throw new RuntimeException("意外的字符: " + ch + " at " + line + ":" + column);
+        }
+        
+        private void skipWhitespace() {
+            while (position < input.length() && Character.isWhitespace(peek())) {
+                if (peek() == '\n') {
+                    line++;
+                    column = 1;
+                } else {
+                    column++;
+                }
+                position++;
+            }
+        }
+        
+        private char peek() {
+            return position < input.length() ? input.charAt(position) : '\0';
+        }
+        
+        private char peekNext() {
+            return position + 1 < input.length() ? input.charAt(position + 1) : '\0';
+        }
+        
+        private void advance() {
+            if (peek() == '\n') {
+                line++;
+                column = 1;
+            } else {
+                column++;
+            }
+            position++;
+        }
+        
+        private Token readIdentifier() {
+            int startColumn = column;
+            StringBuilder sb = new StringBuilder();
+            
+            while (position < input.length() && isIdentifierPart(peek())) {
+                sb.append(peek());
+                advance();
+            }
+            
+            String value = sb.toString();
+            TokenType type = TokenType.IDENTIFIER;
+            
+            // 检查是否是关键字
+            switch (value) {
+                case "text":
+                    type = TokenType.KEYWORD_TEXT;
+                    break;
+                case "style":
+                    type = TokenType.KEYWORD_STYLE;
+                    break;
+                case "script":
+                    type = TokenType.KEYWORD_SCRIPT;
+                    break;
+            }
+            
+            return new Token(type, value, line, startColumn);
+        }
+        
+        private Token readString() {
+            int startColumn = column;
+            char quote = peek();
+            advance(); // 跳过引号
+            
+            StringBuilder sb = new StringBuilder();
+            while (position < input.length() && peek() != quote) {
+                if (peek() == '\\' && peekNext() == quote) {
+                    advance(); // 跳过转义字符
+                    sb.append(quote);
+                    advance();
+                } else {
+                    sb.append(peek());
+                    advance();
+                }
+            }
+            
+            if (peek() == quote) {
+                advance(); // 跳过结束引号
+            } else {
+                throw new RuntimeException("未终止的字符串");
+            }
+            
+            return new Token(TokenType.STRING, sb.toString(), line, startColumn);
+        }
+        
+        private Token readLineComment() {
+            int startColumn = column;
+            advance(); // 跳过第一个/
+            advance(); // 跳过第二个/
+            
+            StringBuilder sb = new StringBuilder("//");
+            while (position < input.length() && peek() != '\n') {
+                sb.append(peek());
+                advance();
+            }
+            
+            return new Token(TokenType.COMMENT, sb.toString(), line, startColumn);
+        }
+        
+        private Token readBlockComment() {
+            int startColumn = column;
+            advance(); // 跳过/
+            advance(); // 跳过*
+            
+            StringBuilder sb = new StringBuilder("/*");
+            while (position < input.length() && !(peek() == '*' && peekNext() == '/')) {
+                sb.append(peek());
+                advance();
+            }
+            
+            if (position < input.length()) {
+                sb.append("*/");
+                advance(); // 跳过*
+                advance(); // 跳过/
+            }
+            
+            return new Token(TokenType.COMMENT, sb.toString(), line, startColumn);
+        }
+        
+        private Token readBracketKeyword() {
+            int startColumn = column;
+            StringBuilder sb = new StringBuilder();
+            
+            while (position < input.length() && peek() != ']') {
+                sb.append(peek());
+                advance();
+            }
+            
+            if (peek() == ']') {
+                sb.append(']');
+                advance();
+            }
+            
+            String value = sb.toString();
+            TokenType type = TokenType.IDENTIFIER;
+            
+            if (value.equals("[Template]")) {
+                type = TokenType.KEYWORD_TEMPLATE;
+            } else if (value.equals("[Custom]")) {
+                type = TokenType.KEYWORD_CUSTOM;
+            }
+            
+            return new Token(type, value, line, startColumn);
+        }
+        
+        private Token readAtKeyword() {
+            int startColumn = column;
+            StringBuilder sb = new StringBuilder();
+            
+            while (position < input.length() && (Character.isLetterOrDigit(peek()) || peek() == '@')) {
+                sb.append(peek());
+                advance();
+            }
+            
+            String value = sb.toString();
+            TokenType type = TokenType.IDENTIFIER;
+            
+            switch (value) {
+                case "@Style":
+                    type = TokenType.AT_STYLE;
+                    break;
+                case "@Element":
+                    type = TokenType.AT_ELEMENT;
+                    break;
+                case "@Var":
+                    type = TokenType.AT_VAR;
+                    break;
+            }
+            
+            return new Token(type, value, line, startColumn);
+        }
+        
+        private boolean isIdentifierStart(char ch) {
+            return Character.isLetter(ch) || ch == '_' || ch == '-';
+        }
+        
+        private boolean isIdentifierPart(char ch) {
+            return Character.isLetterOrDigit(ch) || ch == '_' || ch == '-' || ch == '.';
+        }
+    }
+    
+    // 语法分析器
+    private Lexer lexer;
+    private Token currentToken;
+    private List<Token> tokens;
+    private int tokenIndex;
+    
+    /**
+     * 解析CHTL代码
+     */
+    public CHTLNode parse(String input) {
+        logger.debug("开始解析CHTL代码");
+        
+        // 词法分析
+        lexer = new Lexer(input);
+        tokens = new ArrayList<>();
+        Token token;
+        while ((token = lexer.nextToken()).type != TokenType.EOF) {
+            if (token.type != TokenType.COMMENT) { // 过滤注释
+                tokens.add(token);
+            }
+        }
+        tokens.add(token); // 添加EOF
+        
+        // 语法分析
+        tokenIndex = 0;
+        currentToken = tokens.get(0);
+        
+        ElementNode root = new ElementNode("root");
+        
+        while (currentToken.type != TokenType.EOF) {
+            CHTLNode node = parseTopLevel();
+            if (node != null) {
+                root.addChild(node);
+            }
+        }
+        
+        logger.debug("CHTL解析完成");
+        return root;
+    }
+    
+    private Token consume(TokenType type) {
+        if (currentToken.type != type) {
+            throw new RuntimeException("期望 " + type + " 但得到 " + currentToken.type);
+        }
+        Token token = currentToken;
+        advance();
+        return token;
+    }
+    
+    private void advance() {
+        if (tokenIndex < tokens.size() - 1) {
+            tokenIndex++;
+            currentToken = tokens.get(tokenIndex);
+        }
+    }
+    
+    private CHTLNode parseTopLevel() {
+        switch (currentToken.type) {
+            case KEYWORD_TEMPLATE:
+                return parseTemplate();
+            case KEYWORD_CUSTOM:
+                return parseCustom();
+            case IDENTIFIER:
+            case KEYWORD_TEXT:
+            case KEYWORD_STYLE:
+            case KEYWORD_SCRIPT:
+                return parseElement();
+            default:
+                advance(); // 跳过无法识别的token
+                return null;
+        }
+    }
+    
+    private CHTLNode parseTemplate() {
+        consume(TokenType.KEYWORD_TEMPLATE);
+        
+        TemplateNode.TemplateType type = null;
+        if (currentToken.type == TokenType.AT_STYLE) {
+            type = TemplateNode.TemplateType.STYLE;
+            advance();
+        } else if (currentToken.type == TokenType.AT_ELEMENT) {
+            type = TemplateNode.TemplateType.ELEMENT;
+            advance();
+        } else if (currentToken.type == TokenType.AT_VAR) {
+            type = TemplateNode.TemplateType.VAR;
+            advance();
+        }
+        
+        String name = consume(TokenType.IDENTIFIER).value;
+        TemplateNode template = new TemplateNode(type, name);
+        
+        consume(TokenType.LEFT_BRACE);
+        
+        // 解析模板内容
+        while (currentToken.type != TokenType.RIGHT_BRACE) {
+            CHTLNode child = parseElement();
+            if (child != null) {
+                template.addChild(child);
+            }
+        }
+        
+        consume(TokenType.RIGHT_BRACE);
+        
+        return template;
+    }
+    
+    private CHTLNode parseCustom() {
+        consume(TokenType.KEYWORD_CUSTOM);
+        
+        CustomNode.CustomType type = null;
+        if (currentToken.type == TokenType.AT_STYLE) {
+            type = CustomNode.CustomType.STYLE;
+            advance();
+        } else if (currentToken.type == TokenType.AT_ELEMENT) {
+            type = CustomNode.CustomType.ELEMENT;
+            advance();
+        } else if (currentToken.type == TokenType.AT_VAR) {
+            type = CustomNode.CustomType.VAR;
+            advance();
+        }
+        
+        String name = consume(TokenType.IDENTIFIER).value;
+        CustomNode custom = new CustomNode(type, name);
+        
+        consume(TokenType.LEFT_BRACE);
+        
+        // 解析自定义内容
+        while (currentToken.type != TokenType.RIGHT_BRACE) {
+            CHTLNode child = parseElement();
+            if (child != null) {
+                custom.addChild(child);
+            }
+        }
+        
+        consume(TokenType.RIGHT_BRACE);
+        
+        return custom;
+    }
+    
+    private CHTLNode parseElement() {
+        if (currentToken.type == TokenType.KEYWORD_TEXT) {
+            return parseTextNode();
+        } else if (currentToken.type == TokenType.KEYWORD_STYLE) {
+            return parseStyleNode();
+        } else if (currentToken.type == TokenType.KEYWORD_SCRIPT) {
+            return parseScriptNode();
+        } else if (currentToken.type == TokenType.IDENTIFIER) {
+            String tagName = currentToken.value;
+            advance();
+            
+            ElementNode element = new ElementNode(tagName);
+            
+            consume(TokenType.LEFT_BRACE);
+            
+            // 解析元素内容
+            while (currentToken.type != TokenType.RIGHT_BRACE) {
+                if (currentToken.type == TokenType.IDENTIFIER && 
+                    tokens.get(tokenIndex + 1).type == TokenType.COLON) {
+                    // 解析属性
+                    parseAttribute(element);
+                } else {
+                    // 解析子元素
+                    CHTLNode child = parseElement();
+                    if (child != null) {
+                        element.addChild(child);
+                    }
+                }
+            }
+            
+            consume(TokenType.RIGHT_BRACE);
+            
+            return element;
+        }
+        
+        return null;
+    }
+    
+    private void parseAttribute(ElementNode element) {
+        String name = consume(TokenType.IDENTIFIER).value;
+        consume(TokenType.COLON);
+        
+        String value;
+        if (currentToken.type == TokenType.STRING) {
+            value = currentToken.value;
+            advance();
+        } else if (currentToken.type == TokenType.IDENTIFIER) {
+            // 无引号字面量
+            value = currentToken.value;
+            advance();
+        } else {
+            throw new RuntimeException("期望属性值");
+        }
+        
+        consume(TokenType.SEMICOLON);
+        
+        element.setAttribute(name, value);
+    }
+    
+    private TextNode parseTextNode() {
+        consume(TokenType.KEYWORD_TEXT);
+        consume(TokenType.LEFT_BRACE);
+        
+        String content;
+        if (currentToken.type == TokenType.STRING) {
+            content = currentToken.value;
+            advance();
+        } else {
+            // 读取无引号文本
+            StringBuilder sb = new StringBuilder();
+            while (currentToken.type != TokenType.RIGHT_BRACE) {
+                sb.append(currentToken.value).append(" ");
+                advance();
+            }
+            content = sb.toString().trim();
+        }
+        
+        consume(TokenType.RIGHT_BRACE);
+        
+        return new TextNode(content);
+    }
+    
+    private StyleNode parseStyleNode() {
+        consume(TokenType.KEYWORD_STYLE);
+        consume(TokenType.LEFT_BRACE);
+        
+        StyleNode styleNode = new StyleNode(true); // 局部样式
+        
+        // 简化处理：将style块内容作为原始文本保存
+        StringBuilder content = new StringBuilder();
+        int braceCount = 1;
+        
+        while (braceCount > 0 && currentToken.type != TokenType.EOF) {
+            if (currentToken.type == TokenType.LEFT_BRACE) {
+                braceCount++;
+            } else if (currentToken.type == TokenType.RIGHT_BRACE) {
+                braceCount--;
+                if (braceCount == 0) break;
+            }
+            
+            content.append(currentToken.value).append(" ");
+            advance();
+        }
+        
+        consume(TokenType.RIGHT_BRACE);
+        
+        // 这里简化处理，实际应该解析CSS规则
+        StyleNode.StyleRule rule = new StyleNode.StyleRule("inline");
+        rule.addProperty(new StyleNode.StyleProperty("_raw", content.toString()));
+        styleNode.addRule(rule);
+        
+        return styleNode;
+    }
+    
+    private ScriptNode parseScriptNode() {
+        consume(TokenType.KEYWORD_SCRIPT);
+        consume(TokenType.LEFT_BRACE);
+        
+        // 读取script内容
+        StringBuilder content = new StringBuilder();
+        int braceCount = 1;
+        
+        while (braceCount > 0 && currentToken.type != TokenType.EOF) {
+            if (currentToken.type == TokenType.LEFT_BRACE) {
+                braceCount++;
+            } else if (currentToken.type == TokenType.RIGHT_BRACE) {
+                braceCount--;
+                if (braceCount == 0) break;
+            }
+            
+            content.append(currentToken.value).append(" ");
+            advance();
+        }
+        
+        consume(TokenType.RIGHT_BRACE);
+        
+        return new ScriptNode(content.toString().trim(), true);
+    }
+}

--- a/src/main/java/com/chtl/compiler/chtl/LocalStyleProcessor.java
+++ b/src/main/java/com/chtl/compiler/chtl/LocalStyleProcessor.java
@@ -1,0 +1,93 @@
+package com.chtl.compiler.chtl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 局部样式处理器
+ * 处理CHTL的局部样式块
+ */
+public class LocalStyleProcessor {
+    private static final Logger logger = LoggerFactory.getLogger(LocalStyleProcessor.class);
+    
+    // 正则表达式模式
+    private static final Pattern CLASS_SELECTOR_PATTERN = Pattern.compile(
+        "\\.(\\w+)\\s*\\{([^}]*)\\}", Pattern.DOTALL
+    );
+    
+    private static final Pattern ID_SELECTOR_PATTERN = Pattern.compile(
+        "#(\\w+)\\s*\\{([^}]*)\\}", Pattern.DOTALL
+    );
+    
+    private static final Pattern CONTEXT_SELECTOR_PATTERN = Pattern.compile(
+        "&([:\\w-]+)\\s*\\{([^}]*)\\}", Pattern.DOTALL
+    );
+    
+    private static final Pattern INLINE_STYLE_PATTERN = Pattern.compile(
+        "([\\w-]+)\\s*:\\s*([^;]+);", Pattern.MULTILINE
+    );
+    
+    /**
+     * 处理局部样式
+     */
+    public LocalStyleResult process(String styleContent) {
+        logger.debug("处理局部样式内容");
+        
+        LocalStyleResult result = new LocalStyleResult();
+        
+        // 1. 提取类选择器
+        Matcher classMatcher = CLASS_SELECTOR_PATTERN.matcher(styleContent);
+        while (classMatcher.find()) {
+            String className = classMatcher.group(1);
+            String properties = classMatcher.group(2);
+            
+            result.addGlobalStyle("." + className + " {\n" + properties + "\n}\n");
+            result.addAutoClass(className);
+            
+            // 从原内容中移除已处理的部分
+            styleContent = styleContent.replace(classMatcher.group(), "");
+        }
+        
+        // 2. 提取ID选择器
+        Matcher idMatcher = ID_SELECTOR_PATTERN.matcher(styleContent);
+        while (idMatcher.find()) {
+            String idName = idMatcher.group(1);
+            String properties = idMatcher.group(2);
+            
+            result.addGlobalStyle("#" + idName + " {\n" + properties + "\n}\n");
+            result.setAutoId(idName);
+            
+            styleContent = styleContent.replace(idMatcher.group(), "");
+        }
+        
+        // 3. 提取上下文选择器(&)
+        Matcher contextMatcher = CONTEXT_SELECTOR_PATTERN.matcher(styleContent);
+        while (contextMatcher.find()) {
+            String pseudo = contextMatcher.group(1);
+            String properties = contextMatcher.group(2);
+            
+            // 这部分需要在代码生成时处理，因为需要知道实际的类名
+            result.addContextSelector("&" + pseudo, properties);
+            
+            styleContent = styleContent.replace(contextMatcher.group(), "");
+        }
+        
+        // 4. 剩余的都是内联样式
+        Matcher inlineMatcher = INLINE_STYLE_PATTERN.matcher(styleContent);
+        StringBuilder inlineStyles = new StringBuilder();
+        
+        while (inlineMatcher.find()) {
+            String property = inlineMatcher.group(1);
+            String value = inlineMatcher.group(2).trim();
+            
+            inlineStyles.append(property).append(": ").append(value).append("; ");
+        }
+        
+        result.setInlineStyles(inlineStyles.toString());
+        
+        return result;
+    }
+}

--- a/src/main/java/com/chtl/compiler/chtl/LocalStyleResult.java
+++ b/src/main/java/com/chtl/compiler/chtl/LocalStyleResult.java
@@ -1,0 +1,64 @@
+package com.chtl.compiler.chtl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 局部样式处理结果
+ */
+public class LocalStyleResult {
+    private String inlineStyles;
+    private StringBuilder globalStyles;
+    private List<String> autoClasses;
+    private String autoId;
+    private Map<String, String> contextSelectors;
+    
+    public LocalStyleResult() {
+        this.inlineStyles = "";
+        this.globalStyles = new StringBuilder();
+        this.autoClasses = new ArrayList<>();
+        this.contextSelectors = new HashMap<>();
+    }
+    
+    public String getInlineStyles() {
+        return inlineStyles;
+    }
+    
+    public void setInlineStyles(String inlineStyles) {
+        this.inlineStyles = inlineStyles;
+    }
+    
+    public String getGlobalStyles() {
+        return globalStyles.toString();
+    }
+    
+    public void addGlobalStyle(String style) {
+        globalStyles.append(style).append("\n");
+    }
+    
+    public List<String> getAutoClasses() {
+        return autoClasses;
+    }
+    
+    public void addAutoClass(String className) {
+        autoClasses.add(className);
+    }
+    
+    public String getAutoId() {
+        return autoId;
+    }
+    
+    public void setAutoId(String autoId) {
+        this.autoId = autoId;
+    }
+    
+    public Map<String, String> getContextSelectors() {
+        return contextSelectors;
+    }
+    
+    public void addContextSelector(String selector, String properties) {
+        contextSelectors.put(selector, properties);
+    }
+}

--- a/src/main/java/com/chtl/compiler/chtl/TemplateProcessor.java
+++ b/src/main/java/com/chtl/compiler/chtl/TemplateProcessor.java
@@ -1,0 +1,190 @@
+package com.chtl.compiler.chtl;
+
+import com.chtl.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * 模板处理器
+ * 负责处理模板展开和继承
+ */
+public class TemplateProcessor {
+    private static final Logger logger = LoggerFactory.getLogger(TemplateProcessor.class);
+    
+    private final Map<String, TemplateNode> templates;
+    private final Map<String, CustomNode> customs;
+    
+    public TemplateProcessor(Map<String, TemplateNode> templates, Map<String, CustomNode> customs) {
+        this.templates = templates;
+        this.customs = customs;
+    }
+    
+    /**
+     * 处理AST中的模板展开
+     */
+    public void process(CHTLNode root) {
+        logger.debug("开始处理模板展开");
+        processNode(root);
+    }
+    
+    private void processNode(CHTLNode node) {
+        if (node instanceof ElementNode) {
+            ElementNode element = (ElementNode) node;
+            
+            // 检查是否是模板引用
+            if (isTemplateReference(element)) {
+                expandTemplate(element);
+            } else {
+                // 递归处理子节点
+                for (int i = 0; i < element.getChildren().size(); i++) {
+                    CHTLNode child = element.getChildren().get(i);
+                    processNode(child);
+                }
+            }
+        }
+    }
+    
+    /**
+     * 检查元素是否是模板引用
+     */
+    private boolean isTemplateReference(ElementNode element) {
+        String name = element.getName();
+        return name.startsWith("@Style") || name.startsWith("@Element") || name.startsWith("@Var");
+    }
+    
+    /**
+     * 展开模板
+     */
+    private void expandTemplate(ElementNode element) {
+        String refName = extractTemplateName(element.getName());
+        
+        // 查找对应的模板
+        TemplateNode template = templates.get(refName);
+        if (template == null) {
+            // 尝试在自定义中查找
+            CustomNode custom = customs.get(refName);
+            if (custom != null) {
+                expandCustom(element, custom);
+                return;
+            }
+            
+            logger.warn("未找到模板或自定义: {}", refName);
+            return;
+        }
+        
+        // 展开模板内容
+        CHTLNode parent = element.getParent();
+        if (parent instanceof ElementNode) {
+            ElementNode parentElement = (ElementNode) parent;
+            int index = parentElement.getChildren().indexOf(element);
+            
+            // 移除模板引用
+            parentElement.getChildren().remove(index);
+            
+            // 插入模板内容
+            for (CHTLNode child : template.getChildren()) {
+                CHTLNode clonedChild = cloneNode(child);
+                parentElement.getChildren().add(index++, clonedChild);
+                clonedChild.setParent(parentElement);
+            }
+        }
+    }
+    
+    /**
+     * 展开自定义
+     */
+    private void expandCustom(ElementNode element, CustomNode custom) {
+        // 类似模板展开，但需要处理特例化
+        CHTLNode parent = element.getParent();
+        if (parent instanceof ElementNode) {
+            ElementNode parentElement = (ElementNode) parent;
+            int index = parentElement.getChildren().indexOf(element);
+            
+            // 移除自定义引用
+            parentElement.getChildren().remove(index);
+            
+            // 插入自定义内容
+            for (CHTLNode child : custom.getChildren()) {
+                CHTLNode clonedChild = cloneNode(child);
+                
+                // 处理特例化（如果element有子节点，可能包含特例化信息）
+                if (!element.getChildren().isEmpty()) {
+                    applySpecialization(clonedChild, element);
+                }
+                
+                parentElement.getChildren().add(index++, clonedChild);
+                clonedChild.setParent(parentElement);
+            }
+        }
+    }
+    
+    /**
+     * 提取模板名称
+     */
+    private String extractTemplateName(String fullName) {
+        // 移除@Style、@Element、@Var前缀
+        if (fullName.startsWith("@")) {
+            int spaceIndex = fullName.indexOf(' ');
+            if (spaceIndex > 0) {
+                return fullName.substring(spaceIndex + 1);
+            }
+        }
+        return fullName;
+    }
+    
+    /**
+     * 克隆节点
+     */
+    private CHTLNode cloneNode(CHTLNode node) {
+        if (node instanceof ElementNode) {
+            ElementNode original = (ElementNode) node;
+            ElementNode clone = new ElementNode(original.getName());
+            
+            // 复制属性
+            for (Map.Entry<String, String> attr : original.getAttributes().entrySet()) {
+                clone.setAttribute(attr.getKey(), attr.getValue());
+            }
+            
+            // 递归克隆子节点
+            for (CHTLNode child : original.getChildren()) {
+                clone.addChild(cloneNode(child));
+            }
+            
+            return clone;
+        } else if (node instanceof TextNode) {
+            TextNode original = (TextNode) node;
+            return new TextNode(original.getContent());
+        } else if (node instanceof StyleNode) {
+            StyleNode original = (StyleNode) node;
+            StyleNode clone = new StyleNode(original.isLocal());
+            
+            // 复制样式规则
+            for (StyleNode.StyleRule rule : original.getRules()) {
+                StyleNode.StyleRule clonedRule = new StyleNode.StyleRule(rule.getSelector());
+                for (StyleNode.StyleProperty prop : rule.getProperties()) {
+                    clonedRule.addProperty(new StyleNode.StyleProperty(prop.getName(), prop.getValue()));
+                }
+                clone.addRule(clonedRule);
+            }
+            
+            return clone;
+        } else if (node instanceof ScriptNode) {
+            ScriptNode original = (ScriptNode) node;
+            return new ScriptNode(original.getContent(), original.isLocal());
+        }
+        
+        // 其他类型暂不支持克隆
+        return node;
+    }
+    
+    /**
+     * 应用特例化
+     */
+    private void applySpecialization(CHTLNode target, ElementNode specialization) {
+        // 这里简化处理，实际应该根据特例化语法进行处理
+        // 例如：添加样式、删除元素等
+        logger.debug("应用特例化到节点");
+    }
+}

--- a/src/main/java/com/chtl/compiler/chtljs/CHTLJSCompiler.java
+++ b/src/main/java/com/chtl/compiler/chtljs/CHTLJSCompiler.java
@@ -1,0 +1,414 @@
+package com.chtl.compiler.chtljs;
+
+import com.chtl.model.CodeFragment;
+import com.chtl.model.CompilationResult;
+import com.chtl.model.FragmentType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * CHTL JS编译器 - 手写实现
+ * 负责编译包含CHTL JS特有语法的JavaScript代码
+ */
+public class CHTLJSCompiler {
+    private static final Logger logger = LoggerFactory.getLogger(CHTLJSCompiler.class);
+    
+    // 正则表达式模式
+    private static final Pattern ENHANCED_SELECTOR_PATTERN = Pattern.compile(
+        "\\{\\{([^}]+)\\}\\}", Pattern.MULTILINE
+    );
+    
+    private static final Pattern ARROW_OPERATOR_PATTERN = Pattern.compile(
+        "(\\w+|\\))\\s*->\\s*(\\w+)", Pattern.MULTILINE
+    );
+    
+    private static final Pattern LISTEN_METHOD_PATTERN = Pattern.compile(
+        "->\\s*listen\\s*\\(\\s*\\{([^}]*)\\}\\s*\\)", Pattern.DOTALL
+    );
+    
+    private static final Pattern DELEGATE_METHOD_PATTERN = Pattern.compile(
+        "->\\s*delegate\\s*\\(\\s*\\{([^}]*)\\}\\s*\\)", Pattern.DOTALL
+    );
+    
+    private static final Pattern ANIMATE_FUNCTION_PATTERN = Pattern.compile(
+        "animate\\s*\\(\\s*\\{([^}]*)\\}\\s*\\)", Pattern.DOTALL
+    );
+    
+    // 事件委托注册表管理器
+    private final EventDelegationManager delegationManager;
+    
+    public CHTLJSCompiler() {
+        this.delegationManager = new EventDelegationManager();
+        logger.info("CHTL JS编译器初始化完成");
+    }
+    
+    /**
+     * 编译CHTL JS代码片段
+     */
+    public CompilationResult compile(CodeFragment fragment) {
+        logger.debug("开始编译CHTL JS代码");
+        
+        try {
+            String jsCode = fragment.getContent();
+            
+            // 1. 处理增强选择器 {{}}
+            jsCode = processEnhancedSelectors(jsCode);
+            
+            // 2. 处理箭头操作符 ->
+            jsCode = processArrowOperators(jsCode);
+            
+            // 3. 处理listen方法
+            jsCode = processListenMethod(jsCode);
+            
+            // 4. 处理delegate方法
+            jsCode = processDelegateMethod(jsCode);
+            
+            // 5. 处理animate函数
+            jsCode = processAnimateFunction(jsCode);
+            
+            // 6. 添加必要的辅助函数
+            String finalCode = wrapWithHelperFunctions(jsCode);
+            
+            CompilationResult result = new CompilationResult(FragmentType.CHTL_JS, finalCode);
+            
+            logger.debug("CHTL JS编译成功");
+            return result;
+            
+        } catch (Exception e) {
+            logger.error("CHTL JS编译失败", e);
+            return new CompilationResult(FragmentType.CHTL_JS, "", e.getMessage());
+        }
+    }
+    
+    /**
+     * 处理增强选择器 {{}}
+     */
+    private String processEnhancedSelectors(String code) {
+        Matcher matcher = ENHANCED_SELECTOR_PATTERN.matcher(code);
+        StringBuffer result = new StringBuffer();
+        
+        while (matcher.find()) {
+            String selector = matcher.group(1).trim();
+            String replacement = convertEnhancedSelector(selector);
+            matcher.appendReplacement(result, replacement);
+        }
+        
+        matcher.appendTail(result);
+        return result.toString();
+    }
+    
+    /**
+     * 转换增强选择器为JavaScript代码
+     */
+    private String convertEnhancedSelector(String selector) {
+        // 处理索引访问 如 button[0]
+        if (selector.contains("[") && selector.contains("]")) {
+            int bracketIndex = selector.indexOf("[");
+            String baseSelector = selector.substring(0, bracketIndex);
+            String index = selector.substring(bracketIndex + 1, selector.indexOf("]"));
+            
+            return String.format("_chtl.select('%s')[%s]", baseSelector, index);
+        }
+        
+        // 处理类选择器
+        if (selector.startsWith(".")) {
+            return String.format("_chtl.selectAll('%s')", selector);
+        }
+        
+        // 处理ID选择器
+        if (selector.startsWith("#")) {
+            return String.format("_chtl.selectOne('%s')", selector);
+        }
+        
+        // 处理复合选择器（如 .box button）
+        if (selector.contains(" ")) {
+            return String.format("_chtl.selectAll('%s')", selector);
+        }
+        
+        // 默认：先尝试作为标签，然后尝试类名/ID
+        return String.format("_chtl.smartSelect('%s')", selector);
+    }
+    
+    /**
+     * 处理箭头操作符 ->
+     */
+    private String processArrowOperators(String code) {
+        // 简单替换 -> 为 .
+        return code.replaceAll("->", ".");
+    }
+    
+    /**
+     * 处理listen方法
+     */
+    private String processListenMethod(String code) {
+        Matcher matcher = LISTEN_METHOD_PATTERN.matcher(code);
+        StringBuffer result = new StringBuffer();
+        
+        while (matcher.find()) {
+            String listenContent = matcher.group(1);
+            String replacement = convertListenMethod(listenContent);
+            matcher.appendReplacement(result, replacement);
+        }
+        
+        matcher.appendTail(result);
+        return result.toString();
+    }
+    
+    /**
+     * 转换listen方法
+     */
+    private String convertListenMethod(String content) {
+        StringBuilder js = new StringBuilder(".addEventListener(function() {\n");
+        js.append("  const events = {\n");
+        
+        // 解析事件映射
+        String[] lines = content.split(",");
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (trimmed.contains(":")) {
+                String[] parts = trimmed.split(":", 2);
+                String event = parts[0].trim();
+                String handler = parts[1].trim();
+                
+                js.append(String.format("    '%s': %s,\n", event, handler));
+            }
+        }
+        
+        js.append("  };\n");
+        js.append("  for (let event in events) {\n");
+        js.append("    this.addEventListener(event, events[event]);\n");
+        js.append("  }\n");
+        js.append("}.call(this))");
+        
+        return js.toString();
+    }
+    
+    /**
+     * 处理delegate方法
+     */
+    private String processDelegateMethod(String code) {
+        Matcher matcher = DELEGATE_METHOD_PATTERN.matcher(code);
+        StringBuffer result = new StringBuffer();
+        
+        while (matcher.find()) {
+            String delegateContent = matcher.group(1);
+            String replacement = convertDelegateMethod(delegateContent);
+            matcher.appendReplacement(result, replacement);
+        }
+        
+        matcher.appendTail(result);
+        return result.toString();
+    }
+    
+    /**
+     * 转换delegate方法
+     */
+    private String convertDelegateMethod(String content) {
+        Map<String, String> config = parseDelegateConfig(content);
+        
+        StringBuilder js = new StringBuilder();
+        js.append("._chtlDelegate({\n");
+        js.append("  parent: this,\n");
+        
+        for (Map.Entry<String, String> entry : config.entrySet()) {
+            js.append(String.format("  %s: %s,\n", entry.getKey(), entry.getValue()));
+        }
+        
+        js.append("})");
+        
+        return js.toString();
+    }
+    
+    /**
+     * 解析delegate配置
+     */
+    private Map<String, String> parseDelegateConfig(String content) {
+        Map<String, String> config = new HashMap<>();
+        
+        // 简化解析，实际应该更复杂
+        String[] lines = content.split(",");
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (trimmed.contains(":")) {
+                String[] parts = trimmed.split(":", 2);
+                config.put(parts[0].trim(), parts[1].trim());
+            }
+        }
+        
+        return config;
+    }
+    
+    /**
+     * 处理animate函数
+     */
+    private String processAnimateFunction(String code) {
+        Matcher matcher = ANIMATE_FUNCTION_PATTERN.matcher(code);
+        StringBuffer result = new StringBuffer();
+        
+        while (matcher.find()) {
+            String animateContent = matcher.group(1);
+            String replacement = convertAnimateFunction(animateContent);
+            matcher.appendReplacement(result, replacement);
+        }
+        
+        matcher.appendTail(result);
+        return result.toString();
+    }
+    
+    /**
+     * 转换animate函数
+     */
+    private String convertAnimateFunction(String content) {
+        StringBuilder js = new StringBuilder("_chtl.animate({\n");
+        js.append(content);
+        js.append("\n})");
+        
+        return js.toString();
+    }
+    
+    /**
+     * 包装代码并添加辅助函数
+     */
+    private String wrapWithHelperFunctions(String code) {
+        StringBuilder wrapped = new StringBuilder();
+        
+        // 添加CHTL运行时库
+        wrapped.append("// CHTL JS Runtime\n");
+        wrapped.append("(function() {\n");
+        wrapped.append("  'use strict';\n\n");
+        
+        // 添加辅助对象
+        wrapped.append(generateCHTLHelperObject());
+        
+        wrapped.append("\n  // User code\n");
+        wrapped.append("  " + code.replaceAll("\n", "\n  "));
+        
+        wrapped.append("\n})();\n");
+        
+        return wrapped.toString();
+    }
+    
+    /**
+     * 生成CHTL辅助对象
+     */
+    private String generateCHTLHelperObject() {
+        return """
+            const _chtl = {
+              selectOne: function(selector) {
+                return document.querySelector(selector);
+              },
+              
+              selectAll: function(selector) {
+                return document.querySelectorAll(selector);
+              },
+              
+              select: function(selector) {
+                return document.querySelectorAll(selector);
+              },
+              
+              smartSelect: function(selector) {
+                // 先尝试作为标签
+                let elements = document.getElementsByTagName(selector);
+                if (elements.length > 0) return elements;
+                
+                // 再尝试作为类名
+                elements = document.getElementsByClassName(selector);
+                if (elements.length > 0) return elements;
+                
+                // 最后尝试作为ID
+                const element = document.getElementById(selector);
+                if (element) return [element];
+                
+                return [];
+              },
+              
+              animate: function(config) {
+                const { duration = 1000, easing = 'ease-in-out', begin = {}, 
+                        end = {}, when = [], loop = 1, callback } = config;
+                
+                let currentLoop = 0;
+                const animate = () => {
+                  if (loop !== -1 && currentLoop >= loop) {
+                    if (callback) callback();
+                    return;
+                  }
+                  
+                  // 使用requestAnimationFrame实现动画
+                  const startTime = performance.now();
+                  
+                  const frame = (currentTime) => {
+                    const elapsed = currentTime - startTime;
+                    const progress = Math.min(elapsed / duration, 1);
+                    
+                    // 应用动画样式
+                    // 这里简化处理，实际应该更复杂
+                    
+                    if (progress < 1) {
+                      requestAnimationFrame(frame);
+                    } else {
+                      currentLoop++;
+                      if (loop === -1 || currentLoop < loop) {
+                        animate();
+                      } else if (callback) {
+                        callback();
+                      }
+                    }
+                  };
+                  
+                  requestAnimationFrame(frame);
+                };
+                
+                animate();
+              },
+              
+              _delegationRegistry: new Map(),
+              
+              _chtlDelegate: function(config) {
+                const { parent, target, ...events } = config;
+                
+                // 为父元素创建委托处理器
+                const key = parent;
+                if (!this._delegationRegistry.has(key)) {
+                  this._delegationRegistry.set(key, new Map());
+                }
+                
+                const registry = this._delegationRegistry.get(key);
+                
+                // 注册事件
+                for (let eventType in events) {
+                  if (!registry.has(eventType)) {
+                    parent.addEventListener(eventType, (e) => {
+                      const handlers = registry.get(eventType);
+                      if (handlers) {
+                        handlers.forEach((handler, selector) => {
+                          if (e.target.matches(selector)) {
+                            handler.call(e.target, e);
+                          }
+                        });
+                      }
+                    });
+                    registry.set(eventType, new Map());
+                  }
+                  
+                  const targetSelectors = Array.isArray(target) ? target : [target];
+                  targetSelectors.forEach(selector => {
+                    registry.get(eventType).set(selector, events[eventType]);
+                  });
+                }
+              }
+            };
+            
+            // 扩展Element原型
+            Element.prototype._chtlDelegate = function(config) {
+              config.parent = this;
+              _chtl._chtlDelegate(config);
+              return this;
+            };
+            """;
+    }
+}

--- a/src/main/java/com/chtl/compiler/chtljs/EventDelegationManager.java
+++ b/src/main/java/com/chtl/compiler/chtljs/EventDelegationManager.java
@@ -1,0 +1,98 @@
+package com.chtl.compiler.chtljs;
+
+import java.util.*;
+
+/**
+ * 事件委托管理器
+ * 管理全局事件委托注册表
+ */
+public class EventDelegationManager {
+    // 存储父元素和其委托的事件信息
+    private final Map<String, DelegationInfo> delegationRegistry;
+    
+    public EventDelegationManager() {
+        this.delegationRegistry = new HashMap<>();
+    }
+    
+    /**
+     * 注册事件委托
+     */
+    public void registerDelegation(String parentSelector, String targetSelector, 
+                                  String eventType, String handlerName) {
+        String key = parentSelector + "_" + eventType;
+        
+        DelegationInfo info = delegationRegistry.computeIfAbsent(key, 
+            k -> new DelegationInfo(parentSelector, eventType));
+        
+        info.addTarget(targetSelector, handlerName);
+    }
+    
+    /**
+     * 生成事件委托初始化代码
+     */
+    public String generateInitializationCode() {
+        if (delegationRegistry.isEmpty()) {
+            return "";
+        }
+        
+        StringBuilder code = new StringBuilder();
+        code.append("// Event delegation initialization\n");
+        code.append("document.addEventListener('DOMContentLoaded', function() {\n");
+        
+        for (DelegationInfo info : delegationRegistry.values()) {
+            code.append(info.generateCode()).append("\n");
+        }
+        
+        code.append("});\n");
+        
+        return code.toString();
+    }
+    
+    /**
+     * 事件委托信息内部类
+     */
+    private static class DelegationInfo {
+        private final String parentSelector;
+        private final String eventType;
+        private final List<TargetHandler> targets;
+        
+        public DelegationInfo(String parentSelector, String eventType) {
+            this.parentSelector = parentSelector;
+            this.eventType = eventType;
+            this.targets = new ArrayList<>();
+        }
+        
+        public void addTarget(String targetSelector, String handlerName) {
+            targets.add(new TargetHandler(targetSelector, handlerName));
+        }
+        
+        public String generateCode() {
+            StringBuilder code = new StringBuilder();
+            code.append(String.format("  document.querySelector('%s').addEventListener('%s', function(e) {\n",
+                parentSelector, eventType));
+            
+            for (TargetHandler target : targets) {
+                code.append(String.format("    if (e.target.matches('%s')) {\n", target.selector));
+                code.append(String.format("      %s.call(e.target, e);\n", target.handler));
+                code.append("    }\n");
+            }
+            
+            code.append("  });\n");
+            
+            return code.toString();
+        }
+    }
+    
+    /**
+     * 目标和处理器对
+     */
+    private static class TargetHandler {
+        final String selector;
+        final String handler;
+        
+        TargetHandler(String selector, String handler) {
+            this.selector = selector;
+            this.handler = handler;
+        }
+    }
+}

--- a/src/main/java/com/chtl/compiler/css/CSSCompiler.java
+++ b/src/main/java/com/chtl/compiler/css/CSSCompiler.java
@@ -1,0 +1,238 @@
+package com.chtl.compiler.css;
+
+import com.chtl.css.CSS3Lexer;
+import com.chtl.css.CSS3Parser;
+import com.chtl.model.CodeFragment;
+import com.chtl.model.CompilationResult;
+import com.chtl.model.FragmentType;
+import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.tree.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * CSS编译器 - 基于ANTLR实现
+ * 负责编译和优化CSS代码
+ */
+public class CSSCompiler {
+    private static final Logger logger = LoggerFactory.getLogger(CSSCompiler.class);
+    
+    public CSSCompiler() {
+        logger.info("CSS编译器初始化完成");
+    }
+    
+    /**
+     * 编译CSS代码片段
+     */
+    public CompilationResult compile(CodeFragment fragment) {
+        logger.debug("开始编译CSS代码");
+        
+        try {
+            String cssCode = fragment.getContent();
+            
+            // 1. 使用ANTLR解析CSS
+            CSS3Parser parser = createParser(cssCode);
+            ParseTree tree = parser.stylesheet();
+            
+            // 2. 检查语法错误
+            List<String> errors = checkSyntaxErrors(parser);
+            if (!errors.isEmpty()) {
+                CompilationResult result = new CompilationResult(FragmentType.CSS, cssCode);
+                errors.forEach(result::addError);
+                return result;
+            }
+            
+            // 3. 访问并优化CSS
+            CSSOptimizingVisitor visitor = new CSSOptimizingVisitor();
+            String optimizedCSS = visitor.visit(tree);
+            
+            // 4. 应用额外的优化
+            optimizedCSS = applyOptimizations(optimizedCSS);
+            
+            CompilationResult result = new CompilationResult(FragmentType.CSS, optimizedCSS);
+            
+            // 添加警告信息
+            visitor.getWarnings().forEach(result::addWarning);
+            
+            logger.debug("CSS编译成功");
+            return result;
+            
+        } catch (Exception e) {
+            logger.error("CSS编译失败", e);
+            return new CompilationResult(FragmentType.CSS, "", e.getMessage());
+        }
+    }
+    
+    /**
+     * 创建CSS解析器
+     */
+    private CSS3Parser createParser(String input) {
+        ANTLRInputStream inputStream = new ANTLRInputStream(input);
+        CSS3Lexer lexer = new CSS3Lexer(inputStream);
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        return new CSS3Parser(tokens);
+    }
+    
+    /**
+     * 检查语法错误
+     */
+    private List<String> checkSyntaxErrors(CSS3Parser parser) {
+        List<String> errors = new ArrayList<>();
+        
+        parser.removeErrorListeners();
+        parser.addErrorListener(new BaseErrorListener() {
+            @Override
+            public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol,
+                                  int line, int charPositionInLine, String msg,
+                                  RecognitionException e) {
+                errors.add(String.format("CSS语法错误 [%d:%d]: %s", line, charPositionInLine, msg));
+            }
+        });
+        
+        return errors;
+    }
+    
+    /**
+     * 应用CSS优化
+     */
+    private String applyOptimizations(String css) {
+        // 1. 移除多余的空白
+        css = css.replaceAll("\\s+", " ");
+        css = css.replaceAll("\\s*([{}:;,])\\s*", "$1");
+        
+        // 2. 合并相同的规则
+        css = mergeDuplicateRules(css);
+        
+        // 3. 压缩颜色值
+        css = compressColors(css);
+        
+        // 4. 移除不必要的单位
+        css = removeUnnecessaryUnits(css);
+        
+        return css;
+    }
+    
+    /**
+     * 合并重复的CSS规则
+     */
+    private String mergeDuplicateRules(String css) {
+        // 简化实现，实际应该更复杂
+        return css;
+    }
+    
+    /**
+     * 压缩颜色值
+     */
+    private String compressColors(String css) {
+        // 将 #RRGGBB 转换为 #RGB（如果可能）
+        css = css.replaceAll("#([0-9a-fA-F])\\1([0-9a-fA-F])\\2([0-9a-fA-F])\\3", "#$1$2$3");
+        
+        // 将常见颜色名称转换为更短的十六进制
+        css = css.replaceAll("\\bwhite\\b", "#fff");
+        css = css.replaceAll("\\bblack\\b", "#000");
+        
+        return css;
+    }
+    
+    /**
+     * 移除不必要的单位
+     */
+    private String removeUnnecessaryUnits(String css) {
+        // 移除0值的单位
+        css = css.replaceAll("\\b0px\\b", "0");
+        css = css.replaceAll("\\b0em\\b", "0");
+        css = css.replaceAll("\\b0%\\b", "0");
+        
+        return css;
+    }
+    
+    /**
+     * CSS优化访问器
+     */
+    private static class CSSOptimizingVisitor extends CSS3BaseVisitor<String> {
+        private final List<String> warnings = new ArrayList<>();
+        private final StringBuilder output = new StringBuilder();
+        
+        public List<String> getWarnings() {
+            return warnings;
+        }
+        
+        @Override
+        public String visitStylesheet(CSS3Parser.StylesheetContext ctx) {
+            visitChildren(ctx);
+            return output.toString();
+        }
+        
+        @Override
+        public String visitRuleset(CSS3Parser.RulesetContext ctx) {
+            // 处理规则集
+            if (ctx.selectors() != null) {
+                output.append(ctx.selectors().getText());
+            }
+            output.append("{");
+            
+            if (ctx.declarationList() != null) {
+                visit(ctx.declarationList());
+            }
+            
+            output.append("}");
+            return null;
+        }
+        
+        @Override
+        public String visitDeclaration(CSS3Parser.DeclarationContext ctx) {
+            // 处理声明
+            String property = ctx.property().getText();
+            String value = ctx.expr().getText();
+            
+            // 检查浏览器兼容性
+            checkBrowserCompatibility(property, value);
+            
+            output.append(property).append(":").append(value);
+            
+            if (ctx.important() != null) {
+                output.append("!important");
+            }
+            
+            return null;
+        }
+        
+        @Override
+        public String visitMedia(CSS3Parser.MediaContext ctx) {
+            // 处理媒体查询
+            output.append("@media");
+            if (ctx.mediaQueryList() != null) {
+                output.append(" ").append(ctx.mediaQueryList().getText());
+            }
+            output.append("{");
+            
+            if (ctx.groupRuleBody() != null) {
+                visit(ctx.groupRuleBody());
+            }
+            
+            output.append("}");
+            return null;
+        }
+        
+        private void checkBrowserCompatibility(String property, String value) {
+            // 检查需要浏览器前缀的属性
+            if (property.equals("transform") || property.equals("transition") || 
+                property.equals("animation") || property.equals("flex")) {
+                warnings.add("属性 '" + property + "' 可能需要浏览器前缀以确保兼容性");
+            }
+            
+            // 检查新的CSS特性
+            if (property.startsWith("grid") || property.equals("gap")) {
+                warnings.add("属性 '" + property + "' 是较新的CSS特性，请确保目标浏览器支持");
+            }
+        }
+        
+        @Override
+        protected String aggregateResult(String aggregate, String nextResult) {
+            return output.toString();
+        }
+    }
+}

--- a/src/main/java/com/chtl/compiler/dispatcher/CompilerDispatcher.java
+++ b/src/main/java/com/chtl/compiler/dispatcher/CompilerDispatcher.java
@@ -1,0 +1,126 @@
+package com.chtl.compiler.dispatcher;
+
+import com.chtl.compiler.chtl.CHTLCompiler;
+import com.chtl.compiler.chtljs.CHTLJSCompiler;
+import com.chtl.compiler.css.CSSCompiler;
+import com.chtl.compiler.javascript.JavaScriptCompiler;
+import com.chtl.model.CodeFragment;
+import com.chtl.model.CompilationResult;
+import com.chtl.model.FragmentType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * 编译器调度器
+ * 负责将不同类型的代码片段分发给相应的编译器处理
+ */
+public class CompilerDispatcher {
+    private static final Logger logger = LoggerFactory.getLogger(CompilerDispatcher.class);
+    
+    private final CHTLCompiler chtlCompiler;
+    private final CHTLJSCompiler chtlJsCompiler;
+    private final CSSCompiler cssCompiler;
+    private final JavaScriptCompiler jsCompiler;
+    
+    private final ExecutorService executorService;
+    
+    public CompilerDispatcher() {
+        this.chtlCompiler = new CHTLCompiler();
+        this.chtlJsCompiler = new CHTLJSCompiler();
+        this.cssCompiler = new CSSCompiler();
+        this.jsCompiler = new JavaScriptCompiler();
+        
+        // 创建线程池用于并行编译
+        this.executorService = Executors.newFixedThreadPool(
+            Runtime.getRuntime().availableProcessors()
+        );
+        
+        logger.info("编译器调度器初始化完成");
+    }
+    
+    /**
+     * 调度编译任务
+     * @param fragments 代码片段列表
+     * @return 编译结果列表
+     */
+    public List<CompilationResult> dispatch(List<CodeFragment> fragments) {
+        logger.info("开始调度编译任务，共 {} 个片段", fragments.size());
+        
+        List<CompletableFuture<CompilationResult>> futures = new ArrayList<>();
+        
+        for (CodeFragment fragment : fragments) {
+            CompletableFuture<CompilationResult> future = CompletableFuture
+                .supplyAsync(() -> compileFragment(fragment), executorService);
+            futures.add(future);
+        }
+        
+        // 等待所有编译任务完成
+        List<CompilationResult> results = new ArrayList<>();
+        for (CompletableFuture<CompilationResult> future : futures) {
+            try {
+                results.add(future.get());
+            } catch (Exception e) {
+                logger.error("编译任务执行失败", e);
+                results.add(new CompilationResult(
+                    FragmentType.CHTL, 
+                    "", 
+                    "编译失败: " + e.getMessage()
+                ));
+            }
+        }
+        
+        logger.info("编译调度完成，生成 {} 个结果", results.size());
+        return results;
+    }
+    
+    /**
+     * 编译单个代码片段
+     */
+    private CompilationResult compileFragment(CodeFragment fragment) {
+        logger.debug("编译 {} 类型的代码片段", fragment.getType());
+        
+        try {
+            switch (fragment.getType()) {
+                case CHTL:
+                    return chtlCompiler.compile(fragment);
+                    
+                case CHTL_LOCAL_STYLE:
+                    // 局部样式由CHTL编译器处理
+                    return chtlCompiler.compileLocalStyle(fragment);
+                    
+                case CHTL_JS:
+                    return chtlJsCompiler.compile(fragment);
+                    
+                case CSS:
+                    return cssCompiler.compile(fragment);
+                    
+                case JAVASCRIPT:
+                    return jsCompiler.compile(fragment);
+                    
+                default:
+                    throw new IllegalArgumentException("未知的片段类型: " + fragment.getType());
+            }
+        } catch (Exception e) {
+            logger.error("编译 {} 类型的片段时发生错误", fragment.getType(), e);
+            return new CompilationResult(
+                fragment.getType(), 
+                "", 
+                "编译错误: " + e.getMessage()
+            );
+        }
+    }
+    
+    /**
+     * 关闭调度器
+     */
+    public void shutdown() {
+        logger.info("关闭编译器调度器");
+        executorService.shutdown();
+    }
+}

--- a/src/main/java/com/chtl/compiler/javascript/JavaScriptCompiler.java
+++ b/src/main/java/com/chtl/compiler/javascript/JavaScriptCompiler.java
@@ -1,0 +1,287 @@
+package com.chtl.compiler.javascript;
+
+import com.chtl.javascript.ECMAScriptLexer;
+import com.chtl.javascript.ECMAScriptParser;
+import com.chtl.model.CodeFragment;
+import com.chtl.model.CompilationResult;
+import com.chtl.model.FragmentType;
+import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.tree.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.function.BiPredicate;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.function.BiPredicate;
+
+/**
+ * JavaScript编译器 - 基于ANTLR实现
+ * 负责编译和优化JavaScript代码
+ */
+public class JavaScriptCompiler {
+    private static final Logger logger = LoggerFactory.getLogger(JavaScriptCompiler.class);
+    
+    public JavaScriptCompiler() {
+        logger.info("JavaScript编译器初始化完成");
+    }
+    
+    /**
+     * 编译JavaScript代码片段
+     */
+    public CompilationResult compile(CodeFragment fragment) {
+        logger.debug("开始编译JavaScript代码");
+        
+        try {
+            String jsCode = fragment.getContent();
+            
+            // 1. 使用ANTLR解析JavaScript
+            ECMAScriptParser parser = createParser(jsCode);
+            ParseTree tree = parser.program();
+            
+            // 2. 检查语法错误
+            List<String> errors = checkSyntaxErrors(parser);
+            if (!errors.isEmpty()) {
+                CompilationResult result = new CompilationResult(FragmentType.JAVASCRIPT, jsCode);
+                errors.forEach(result::addError);
+                return result;
+            }
+            
+            // 3. 访问并优化JavaScript
+            JavaScriptOptimizingVisitor visitor = new JavaScriptOptimizingVisitor();
+            String optimizedJS = visitor.visit(tree);
+            
+            // 4. 应用额外的优化
+            optimizedJS = applyOptimizations(optimizedJS);
+            
+            CompilationResult result = new CompilationResult(FragmentType.JAVASCRIPT, optimizedJS);
+            
+            // 添加警告信息
+            visitor.getWarnings().forEach(result::addWarning);
+            
+            logger.debug("JavaScript编译成功");
+            return result;
+            
+        } catch (Exception e) {
+            logger.error("JavaScript编译失败", e);
+            return new CompilationResult(FragmentType.JAVASCRIPT, "", e.getMessage());
+        }
+    }
+    
+    /**
+     * 创建JavaScript解析器
+     */
+    private ECMAScriptParser createParser(String input) {
+        ANTLRInputStream inputStream = new ANTLRInputStream(input);
+        ECMAScriptLexer lexer = new ECMAScriptLexer(inputStream);
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        ECMAScriptParser parser = new ECMAScriptParser(tokens);
+        
+        // 添加预测函数
+        parser.addPredicate("notOpenBraceAndNotFunction", this::notOpenBraceAndNotFunction);
+        parser.addPredicate("notLineTerminator", this::notLineTerminator);
+        parser.addPredicate("lineTerminatorAhead", this::lineTerminatorAhead);
+        parser.addPredicate("p", this::checkNext);
+        
+        return parser;
+    }
+    
+    /**
+     * 检查语法错误
+     */
+    private List<String> checkSyntaxErrors(ECMAScriptParser parser) {
+        List<String> errors = new ArrayList<>();
+        
+        parser.removeErrorListeners();
+        parser.addErrorListener(new BaseErrorListener() {
+            @Override
+            public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol,
+                                  int line, int charPositionInLine, String msg,
+                                  RecognitionException e) {
+                errors.add(String.format("JavaScript语法错误 [%d:%d]: %s", line, charPositionInLine, msg));
+            }
+        });
+        
+        return errors;
+    }
+    
+    /**
+     * 应用JavaScript优化
+     */
+    private String applyOptimizations(String js) {
+        // 1. 移除多余的分号
+        js = removeRedundantSemicolons(js);
+        
+        // 2. 压缩变量名（在生产环境）
+        // js = compressVariableNames(js);
+        
+        // 3. 移除调试代码
+        js = removeDebugCode(js);
+        
+        // 4. 优化条件表达式
+        js = optimizeConditionals(js);
+        
+        return js;
+    }
+    
+    /**
+     * 移除多余的分号
+     */
+    private String removeRedundantSemicolons(String js) {
+        // 移除块结束前的分号
+        js = js.replaceAll(";\\s*}", "}");
+        
+        // 移除连续的分号
+        js = js.replaceAll(";+", ";");
+        
+        return js;
+    }
+    
+    /**
+     * 移除调试代码
+     */
+    private String removeDebugCode(String js) {
+        // 移除console.log语句（可配置）
+        // js = js.replaceAll("console\\.log\\([^)]*\\);?", "");
+        
+        // 移除debugger语句
+        js = js.replaceAll("\\bdebugger\\s*;", "");
+        
+        return js;
+    }
+    
+    /**
+     * 优化条件表达式
+     */
+    private String optimizeConditionals(String js) {
+        // 将 if (x == true) 优化为 if (x)
+        js = js.replaceAll("if\\s*\\(([^)]+)\\s*==\\s*true\\)", "if($1)");
+        js = js.replaceAll("if\\s*\\(([^)]+)\\s*===\\s*true\\)", "if($1)");
+        
+        // 将 if (x == false) 优化为 if (!x)
+        js = js.replaceAll("if\\s*\\(([^)]+)\\s*==\\s*false\\)", "if(!$1)");
+        js = js.replaceAll("if\\s*\\(([^)]+)\\s*===\\s*false\\)", "if(!$1)");
+        
+        return js;
+    }
+    
+    // 预测函数实现
+    private boolean notOpenBraceAndNotFunction(RuleContext context) {
+        return true; // 简化实现
+    }
+    
+    private boolean notLineTerminator(RuleContext context) {
+        return true; // 简化实现
+    }
+    
+    private boolean lineTerminatorAhead(RuleContext context) {
+        return false; // 简化实现
+    }
+    
+    private boolean checkNext(RuleContext context, String value) {
+        return true; // 简化实现
+    }
+    
+    /**
+     * JavaScript优化访问器
+     */
+    private static class JavaScriptOptimizingVisitor extends ECMAScriptBaseVisitor<String> {
+        private final List<String> warnings = new ArrayList<>();
+        private final StringBuilder output = new StringBuilder();
+        
+        public List<String> getWarnings() {
+            return warnings;
+        }
+        
+        @Override
+        public String visitProgram(ECMAScriptParser.ProgramContext ctx) {
+            if (ctx.sourceElements() != null) {
+                visit(ctx.sourceElements());
+            }
+            return output.toString();
+        }
+        
+        @Override
+        public String visitVariableStatement(ECMAScriptParser.VariableStatementContext ctx) {
+            String varType = ctx.varModifier().getText();
+            
+            // 检查var使用
+            if ("var".equals(varType)) {
+                warnings.add("建议使用 'let' 或 'const' 替代 'var' 以避免作用域问题");
+            }
+            
+            output.append(varType).append(" ");
+            visit(ctx.variableDeclarationList());
+            output.append(";");
+            
+            return null;
+        }
+        
+        @Override
+        public String visitFunctionDeclaration(ECMAScriptParser.FunctionDeclarationContext ctx) {
+            output.append("function ");
+            output.append(ctx.Identifier().getText());
+            output.append("(");
+            
+            if (ctx.formalParameterList() != null) {
+                visit(ctx.formalParameterList());
+            }
+            
+            output.append("){");
+            
+            if (ctx.functionBody() != null) {
+                visit(ctx.functionBody());
+            }
+            
+            output.append("}");
+            
+            return null;
+        }
+        
+        @Override
+        public String visitWithStatement(ECMAScriptParser.WithStatementContext ctx) {
+            warnings.add("不建议使用 'with' 语句，它可能导致性能问题和代码混淆");
+            
+            output.append("with(");
+            visit(ctx.expressionSequence());
+            output.append(")");
+            visit(ctx.statement());
+            
+            return null;
+        }
+        
+        @Override
+        public String visitTerminal(TerminalNode node) {
+            output.append(node.getText()).append(" ");
+            return null;
+        }
+        
+        @Override
+        protected String aggregateResult(String aggregate, String nextResult) {
+            return output.toString();
+        }
+    }
+}
+
+// 扩展ECMAScriptParser以支持预测
+class ECMAScriptParser extends ECMAScriptBaseParser {
+    private final Map<String, BiPredicate<RuleContext, String>> predicates = new HashMap<>();
+    
+    public ECMAScriptParser(TokenStream input) {
+        super(input);
+    }
+    
+    public void addPredicate(String name, BiPredicate<RuleContext, String> predicate) {
+        predicates.put(name, predicate);
+    }
+    
+    @Override
+    public boolean sempred(RuleContext _localctx, int ruleIndex, int predIndex) {
+        // 实现语义预测
+        return true;
+    }
+}

--- a/src/main/java/com/chtl/model/AttributeNode.java
+++ b/src/main/java/com/chtl/model/AttributeNode.java
@@ -1,0 +1,26 @@
+package com.chtl.model;
+
+/**
+ * 属性节点
+ */
+public class AttributeNode extends CHTLNode {
+    private String value;
+    
+    public AttributeNode(String name, String value) {
+        super(name);
+        this.value = value;
+    }
+    
+    public String getValue() {
+        return value;
+    }
+    
+    public void setValue(String value) {
+        this.value = value;
+    }
+    
+    @Override
+    public void accept(CHTLNodeVisitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/src/main/java/com/chtl/model/CHTLNode.java
+++ b/src/main/java/com/chtl/model/CHTLNode.java
@@ -1,0 +1,59 @@
+package com.chtl.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * CHTL语法树节点基类
+ */
+public abstract class CHTLNode {
+    protected String name;
+    protected List<CHTLNode> children;
+    protected CHTLNode parent;
+    protected int lineNumber;
+    protected int columnNumber;
+    
+    public CHTLNode(String name) {
+        this.name = name;
+        this.children = new ArrayList<>();
+    }
+    
+    public void addChild(CHTLNode child) {
+        children.add(child);
+        child.setParent(this);
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    public List<CHTLNode> getChildren() {
+        return children;
+    }
+    
+    public CHTLNode getParent() {
+        return parent;
+    }
+    
+    public void setParent(CHTLNode parent) {
+        this.parent = parent;
+    }
+    
+    public int getLineNumber() {
+        return lineNumber;
+    }
+    
+    public void setLineNumber(int lineNumber) {
+        this.lineNumber = lineNumber;
+    }
+    
+    public int getColumnNumber() {
+        return columnNumber;
+    }
+    
+    public void setColumnNumber(int columnNumber) {
+        this.columnNumber = columnNumber;
+    }
+    
+    public abstract void accept(CHTLNodeVisitor visitor);
+}

--- a/src/main/java/com/chtl/model/CHTLNodeVisitor.java
+++ b/src/main/java/com/chtl/model/CHTLNodeVisitor.java
@@ -1,0 +1,14 @@
+package com.chtl.model;
+
+/**
+ * CHTL节点访问者接口
+ */
+public interface CHTLNodeVisitor {
+    void visit(ElementNode node);
+    void visit(TextNode node);
+    void visit(AttributeNode node);
+    void visit(StyleNode node);
+    void visit(ScriptNode node);
+    void visit(TemplateNode node);
+    void visit(CustomNode node);
+}

--- a/src/main/java/com/chtl/model/CodeFragment.java
+++ b/src/main/java/com/chtl/model/CodeFragment.java
@@ -1,0 +1,34 @@
+package com.chtl.model;
+
+/**
+ * 代码片段模型
+ */
+public class CodeFragment {
+    private final FragmentType type;
+    private final String content;
+    private final int sourcePosition;
+    
+    public CodeFragment(FragmentType type, String content, int sourcePosition) {
+        this.type = type;
+        this.content = content;
+        this.sourcePosition = sourcePosition;
+    }
+    
+    public FragmentType getType() {
+        return type;
+    }
+    
+    public String getContent() {
+        return content;
+    }
+    
+    public int getSourcePosition() {
+        return sourcePosition;
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("CodeFragment{type=%s, position=%d, contentLength=%d}", 
+            type, sourcePosition, content.length());
+    }
+}

--- a/src/main/java/com/chtl/model/CompilationResult.java
+++ b/src/main/java/com/chtl/model/CompilationResult.java
@@ -1,0 +1,77 @@
+package com.chtl.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 编译结果模型
+ */
+public class CompilationResult {
+    private final FragmentType sourceType;
+    private final String compiledContent;
+    private final List<String> errors;
+    private final List<String> warnings;
+    
+    // 额外的元数据
+    private String generatedCSS;
+    private String generatedJS;
+    
+    public CompilationResult(FragmentType sourceType, String compiledContent) {
+        this(sourceType, compiledContent, null);
+    }
+    
+    public CompilationResult(FragmentType sourceType, String compiledContent, String error) {
+        this.sourceType = sourceType;
+        this.compiledContent = compiledContent;
+        this.errors = new ArrayList<>();
+        this.warnings = new ArrayList<>();
+        
+        if (error != null && !error.isEmpty()) {
+            this.errors.add(error);
+        }
+    }
+    
+    public FragmentType getSourceType() {
+        return sourceType;
+    }
+    
+    public String getCompiledContent() {
+        return compiledContent;
+    }
+    
+    public List<String> getErrors() {
+        return errors;
+    }
+    
+    public List<String> getWarnings() {
+        return warnings;
+    }
+    
+    public boolean hasErrors() {
+        return !errors.isEmpty();
+    }
+    
+    public void addError(String error) {
+        errors.add(error);
+    }
+    
+    public void addWarning(String warning) {
+        warnings.add(warning);
+    }
+    
+    public String getGeneratedCSS() {
+        return generatedCSS;
+    }
+    
+    public void setGeneratedCSS(String generatedCSS) {
+        this.generatedCSS = generatedCSS;
+    }
+    
+    public String getGeneratedJS() {
+        return generatedJS;
+    }
+    
+    public void setGeneratedJS(String generatedJS) {
+        this.generatedJS = generatedJS;
+    }
+}

--- a/src/main/java/com/chtl/model/CustomNode.java
+++ b/src/main/java/com/chtl/model/CustomNode.java
@@ -1,0 +1,44 @@
+package com.chtl.model;
+
+/**
+ * 自定义节点
+ */
+public class CustomNode extends CHTLNode {
+    private CustomType type;
+    private String customName;
+    
+    public enum CustomType {
+        STYLE("@Style"),
+        ELEMENT("@Element"),
+        VAR("@Var");
+        
+        private final String keyword;
+        
+        CustomType(String keyword) {
+            this.keyword = keyword;
+        }
+        
+        public String getKeyword() {
+            return keyword;
+        }
+    }
+    
+    public CustomNode(CustomType type, String customName) {
+        super("custom");
+        this.type = type;
+        this.customName = customName;
+    }
+    
+    public CustomType getType() {
+        return type;
+    }
+    
+    public String getCustomName() {
+        return customName;
+    }
+    
+    @Override
+    public void accept(CHTLNodeVisitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/src/main/java/com/chtl/model/ElementNode.java
+++ b/src/main/java/com/chtl/model/ElementNode.java
@@ -1,0 +1,33 @@
+package com.chtl.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 元素节点
+ */
+public class ElementNode extends CHTLNode {
+    private Map<String, String> attributes;
+    
+    public ElementNode(String tagName) {
+        super(tagName);
+        this.attributes = new HashMap<>();
+    }
+    
+    public void setAttribute(String name, String value) {
+        attributes.put(name, value);
+    }
+    
+    public String getAttribute(String name) {
+        return attributes.get(name);
+    }
+    
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+    
+    @Override
+    public void accept(CHTLNodeVisitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/src/main/java/com/chtl/model/FragmentType.java
+++ b/src/main/java/com/chtl/model/FragmentType.java
@@ -1,0 +1,41 @@
+package com.chtl.model;
+
+/**
+ * 代码片段类型枚举
+ */
+public enum FragmentType {
+    /**
+     * CHTL主体代码
+     */
+    CHTL("CHTL主体代码"),
+    
+    /**
+     * CHTL局部样式（style块）
+     */
+    CHTL_LOCAL_STYLE("CHTL局部样式"),
+    
+    /**
+     * CHTL JS代码（包含CHTL JS特有语法）
+     */
+    CHTL_JS("CHTL JS代码"),
+    
+    /**
+     * 纯CSS代码（全局样式）
+     */
+    CSS("CSS代码"),
+    
+    /**
+     * 纯JavaScript代码
+     */
+    JAVASCRIPT("JavaScript代码");
+    
+    private final String description;
+    
+    FragmentType(String description) {
+        this.description = description;
+    }
+    
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/chtl/model/ScriptNode.java
+++ b/src/main/java/com/chtl/model/ScriptNode.java
@@ -1,0 +1,32 @@
+package com.chtl.model;
+
+/**
+ * 脚本节点
+ */
+public class ScriptNode extends CHTLNode {
+    private String content;
+    private boolean isLocal;
+    
+    public ScriptNode(String content, boolean isLocal) {
+        super("script");
+        this.content = content;
+        this.isLocal = isLocal;
+    }
+    
+    public String getContent() {
+        return content;
+    }
+    
+    public void setContent(String content) {
+        this.content = content;
+    }
+    
+    public boolean isLocal() {
+        return isLocal;
+    }
+    
+    @Override
+    public void accept(CHTLNodeVisitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/src/main/java/com/chtl/model/StyleNode.java
+++ b/src/main/java/com/chtl/model/StyleNode.java
@@ -1,0 +1,81 @@
+package com.chtl.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 样式节点
+ */
+public class StyleNode extends CHTLNode {
+    private boolean isLocal;
+    private List<StyleRule> rules;
+    
+    public StyleNode(boolean isLocal) {
+        super("style");
+        this.isLocal = isLocal;
+        this.rules = new ArrayList<>();
+    }
+    
+    public boolean isLocal() {
+        return isLocal;
+    }
+    
+    public List<StyleRule> getRules() {
+        return rules;
+    }
+    
+    public void addRule(StyleRule rule) {
+        rules.add(rule);
+    }
+    
+    @Override
+    public void accept(CHTLNodeVisitor visitor) {
+        visitor.visit(this);
+    }
+    
+    /**
+     * 样式规则内部类
+     */
+    public static class StyleRule {
+        private String selector;
+        private List<StyleProperty> properties;
+        
+        public StyleRule(String selector) {
+            this.selector = selector;
+            this.properties = new ArrayList<>();
+        }
+        
+        public String getSelector() {
+            return selector;
+        }
+        
+        public List<StyleProperty> getProperties() {
+            return properties;
+        }
+        
+        public void addProperty(StyleProperty property) {
+            properties.add(property);
+        }
+    }
+    
+    /**
+     * 样式属性内部类
+     */
+    public static class StyleProperty {
+        private String name;
+        private String value;
+        
+        public StyleProperty(String name, String value) {
+            this.name = name;
+            this.value = value;
+        }
+        
+        public String getName() {
+            return name;
+        }
+        
+        public String getValue() {
+            return value;
+        }
+    }
+}

--- a/src/main/java/com/chtl/model/TemplateNode.java
+++ b/src/main/java/com/chtl/model/TemplateNode.java
@@ -1,0 +1,44 @@
+package com.chtl.model;
+
+/**
+ * 模板节点
+ */
+public class TemplateNode extends CHTLNode {
+    private TemplateType type;
+    private String templateName;
+    
+    public enum TemplateType {
+        STYLE("@Style"),
+        ELEMENT("@Element"),
+        VAR("@Var");
+        
+        private final String keyword;
+        
+        TemplateType(String keyword) {
+            this.keyword = keyword;
+        }
+        
+        public String getKeyword() {
+            return keyword;
+        }
+    }
+    
+    public TemplateNode(TemplateType type, String templateName) {
+        super("template");
+        this.type = type;
+        this.templateName = templateName;
+    }
+    
+    public TemplateType getType() {
+        return type;
+    }
+    
+    public String getTemplateName() {
+        return templateName;
+    }
+    
+    @Override
+    public void accept(CHTLNodeVisitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/src/main/java/com/chtl/model/TextNode.java
+++ b/src/main/java/com/chtl/model/TextNode.java
@@ -1,0 +1,26 @@
+package com.chtl.model;
+
+/**
+ * 文本节点
+ */
+public class TextNode extends CHTLNode {
+    private String content;
+    
+    public TextNode(String content) {
+        super("text");
+        this.content = content;
+    }
+    
+    public String getContent() {
+        return content;
+    }
+    
+    public void setContent(String content) {
+        this.content = content;
+    }
+    
+    @Override
+    public void accept(CHTLNodeVisitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/src/main/java/com/chtl/output/HTMLMerger.java
+++ b/src/main/java/com/chtl/output/HTMLMerger.java
@@ -1,0 +1,302 @@
+package com.chtl.output;
+
+import com.chtl.model.CompilationResult;
+import com.chtl.model.FragmentType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+
+/**
+ * HTML合并器
+ * 负责将各个编译器的结果合并成最终的HTML文档
+ */
+public class HTMLMerger {
+    private static final Logger logger = LoggerFactory.getLogger(HTMLMerger.class);
+    
+    public HTMLMerger() {
+        logger.info("HTML合并器初始化完成");
+    }
+    
+    /**
+     * 合并编译结果
+     * @param results 编译结果列表
+     * @return 完整的HTML文档
+     */
+    public String merge(List<CompilationResult> results) {
+        logger.debug("开始合并编译结果，共 {} 个片段", results.size());
+        
+        // 分类结果
+        List<CompilationResult> htmlResults = new ArrayList<>();
+        List<CompilationResult> cssResults = new ArrayList<>();
+        List<CompilationResult> jsResults = new ArrayList<>();
+        StringBuilder additionalCSS = new StringBuilder();
+        StringBuilder additionalJS = new StringBuilder();
+        
+        for (CompilationResult result : results) {
+            switch (result.getSourceType()) {
+                case CHTL:
+                case CHTL_LOCAL_STYLE:
+                    htmlResults.add(result);
+                    // 收集生成的CSS和JS
+                    if (result.getGeneratedCSS() != null && !result.getGeneratedCSS().isEmpty()) {
+                        additionalCSS.append(result.getGeneratedCSS()).append("\n");
+                    }
+                    if (result.getGeneratedJS() != null && !result.getGeneratedJS().isEmpty()) {
+                        additionalJS.append(result.getGeneratedJS()).append("\n");
+                    }
+                    break;
+                case CSS:
+                    cssResults.add(result);
+                    break;
+                case CHTL_JS:
+                case JAVASCRIPT:
+                    jsResults.add(result);
+                    break;
+            }
+        }
+        
+        // 构建HTML文档
+        HTMLBuilder builder = new HTMLBuilder();
+        
+        // 1. 合并HTML内容
+        String mainHTML = mergeHTMLContent(htmlResults);
+        
+        // 2. 合并CSS
+        String allCSS = mergeCSSContent(cssResults, additionalCSS.toString());
+        
+        // 3. 合并JavaScript
+        String allJS = mergeJavaScriptContent(jsResults, additionalJS.toString());
+        
+        // 4. 构建最终HTML
+        String finalHTML = builder.build(mainHTML, allCSS, allJS);
+        
+        // 5. 后处理优化
+        finalHTML = postProcess(finalHTML);
+        
+        logger.debug("HTML合并完成");
+        return finalHTML;
+    }
+    
+    /**
+     * 合并HTML内容
+     */
+    private String mergeHTMLContent(List<CompilationResult> results) {
+        return results.stream()
+            .filter(r -> !r.hasErrors())
+            .map(CompilationResult::getCompiledContent)
+            .collect(Collectors.joining("\n"));
+    }
+    
+    /**
+     * 合并CSS内容
+     */
+    private String mergeCSSContent(List<CompilationResult> cssResults, String additionalCSS) {
+        StringBuilder css = new StringBuilder();
+        
+        // 添加CSS重置样式（可选）
+        css.append(getCSSReset()).append("\n");
+        
+        // 合并所有CSS结果
+        for (CompilationResult result : cssResults) {
+            if (!result.hasErrors()) {
+                css.append(result.getCompiledContent()).append("\n");
+            }
+        }
+        
+        // 添加额外的CSS（来自CHTL编译器）
+        css.append(additionalCSS);
+        
+        return optimizeCSS(css.toString());
+    }
+    
+    /**
+     * 合并JavaScript内容
+     */
+    private String mergeJavaScriptContent(List<CompilationResult> jsResults, String additionalJS) {
+        StringBuilder js = new StringBuilder();
+        
+        // 添加CHTL运行时（如果需要）
+        boolean needsCHTLRuntime = jsResults.stream()
+            .anyMatch(r -> r.getSourceType() == FragmentType.CHTL_JS);
+        
+        if (needsCHTLRuntime) {
+            js.append("// CHTL Runtime included\n");
+        }
+        
+        // 合并所有JS结果
+        for (CompilationResult result : jsResults) {
+            if (!result.hasErrors()) {
+                js.append(result.getCompiledContent()).append("\n");
+            }
+        }
+        
+        // 添加额外的JS（来自CHTL编译器）
+        js.append(additionalJS);
+        
+        return optimizeJS(js.toString());
+    }
+    
+    /**
+     * 获取CSS重置样式
+     */
+    private String getCSSReset() {
+        return """
+            /* CSS Reset */
+            * {
+                margin: 0;
+                padding: 0;
+                box-sizing: border-box;
+            }
+            
+            html {
+                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 
+                           'Helvetica Neue', Arial, sans-serif;
+                font-size: 16px;
+                line-height: 1.5;
+                color: #333;
+            }
+            """;
+    }
+    
+    /**
+     * 优化CSS
+     */
+    private String optimizeCSS(String css) {
+        // 移除重复规则
+        // 合并相同选择器
+        // 压缩空白
+        return css.trim();
+    }
+    
+    /**
+     * 优化JavaScript
+     */
+    private String optimizeJS(String js) {
+        // 移除重复代码
+        // 合并相同函数
+        return js.trim();
+    }
+    
+    /**
+     * 后处理优化
+     */
+    private String postProcess(String html) {
+        // 格式化HTML
+        html = formatHTML(html);
+        
+        // 添加必要的meta标签
+        html = ensureMetaTags(html);
+        
+        return html;
+    }
+    
+    /**
+     * 格式化HTML
+     */
+    private String formatHTML(String html) {
+        // 简单的格式化，实际可以使用更复杂的格式化库
+        return html;
+    }
+    
+    /**
+     * 确保必要的meta标签存在
+     */
+    private String ensureMetaTags(String html) {
+        if (!html.contains("<meta charset=")) {
+            html = html.replace("<head>", "<head>\n  <meta charset=\"UTF-8\">");
+        }
+        
+        if (!html.contains("<meta name=\"viewport\"")) {
+            html = html.replace("<head>", 
+                "<head>\n  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">");
+        }
+        
+        return html;
+    }
+    
+    /**
+     * HTML构建器内部类
+     */
+    private static class HTMLBuilder {
+        
+        public String build(String bodyContent, String css, String js) {
+            StringBuilder html = new StringBuilder();
+            
+            // 检查是否已有完整的HTML结构
+            if (bodyContent.contains("<html") && bodyContent.contains("</html>")) {
+                // 已有完整结构，插入CSS和JS
+                return insertAssetsIntoExistingHTML(bodyContent, css, js);
+            }
+            
+            // 构建新的HTML结构
+            html.append("<!DOCTYPE html>\n");
+            html.append("<html lang=\"zh-CN\">\n");
+            html.append("<head>\n");
+            html.append("  <meta charset=\"UTF-8\">\n");
+            html.append("  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n");
+            html.append("  <title>CHTL Generated Page</title>\n");
+            
+            // 添加CSS
+            if (!css.isEmpty()) {
+                html.append("  <style>\n");
+                html.append(indentCSS(css, "    "));
+                html.append("  </style>\n");
+            }
+            
+            html.append("</head>\n");
+            html.append("<body>\n");
+            
+            // 添加主体内容
+            html.append(indentHTML(bodyContent, "  "));
+            
+            // 添加JavaScript
+            if (!js.isEmpty()) {
+                html.append("  <script>\n");
+                html.append(indentJS(js, "    "));
+                html.append("  </script>\n");
+            }
+            
+            html.append("</body>\n");
+            html.append("</html>\n");
+            
+            return html.toString();
+        }
+        
+        private String insertAssetsIntoExistingHTML(String html, String css, String js) {
+            // 在</head>前插入CSS
+            if (!css.isEmpty()) {
+                String styleTag = "<style>\n" + css + "\n</style>\n";
+                html = html.replace("</head>", styleTag + "</head>");
+            }
+            
+            // 在</body>前插入JS
+            if (!js.isEmpty()) {
+                String scriptTag = "<script>\n" + js + "\n</script>\n";
+                html = html.replace("</body>", scriptTag + "</body>");
+            }
+            
+            return html;
+        }
+        
+        private String indentCSS(String css, String indent) {
+            return css.lines()
+                     .map(line -> indent + line)
+                     .collect(Collectors.joining("\n")) + "\n";
+        }
+        
+        private String indentHTML(String html, String indent) {
+            return html.lines()
+                     .map(line -> indent + line)
+                     .collect(Collectors.joining("\n")) + "\n";
+        }
+        
+        private String indentJS(String js, String indent) {
+            return js.lines()
+                     .map(line -> indent + line)
+                     .collect(Collectors.joining("\n")) + "\n";
+        }
+    }
+}

--- a/src/main/java/com/chtl/scanner/CHTLUnifiedScanner.java
+++ b/src/main/java/com/chtl/scanner/CHTLUnifiedScanner.java
@@ -1,0 +1,190 @@
+package com.chtl.scanner;
+
+import com.chtl.model.CodeFragment;
+import com.chtl.model.FragmentType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * CHTL统一扫描器 - 精准代码切割器
+ * 负责将CHTL源代码切割成不同类型的片段
+ */
+public class CHTLUnifiedScanner {
+    private static final Logger logger = LoggerFactory.getLogger(CHTLUnifiedScanner.class);
+    
+    // 正则表达式模式
+    private static final Pattern STYLE_BLOCK_PATTERN = Pattern.compile(
+        "style\\s*\\{([^{}]*(?:\\{[^{}]*\\}[^{}]*)*)\\}", 
+        Pattern.DOTALL | Pattern.MULTILINE
+    );
+    
+    private static final Pattern SCRIPT_BLOCK_PATTERN = Pattern.compile(
+        "script\\s*\\{([^{}]*(?:\\{[^{}]*\\}[^{}]*)*)\\}", 
+        Pattern.DOTALL | Pattern.MULTILINE
+    );
+    
+    private static final Pattern GLOBAL_STYLE_PATTERN = Pattern.compile(
+        "\\[Origin\\]\\s*@Style\\s*\\{([^}]*)\\}", 
+        Pattern.DOTALL | Pattern.MULTILINE
+    );
+    
+    private static final Pattern COMMENT_PATTERN = Pattern.compile(
+        "//.*?$|/\\*.*?\\*/", 
+        Pattern.MULTILINE | Pattern.DOTALL
+    );
+    
+    public CHTLUnifiedScanner() {
+        logger.info("初始化CHTL统一扫描器");
+    }
+    
+    /**
+     * 扫描并切割CHTL源代码
+     * @param sourceCode CHTL源代码
+     * @return 代码片段列表
+     */
+    public List<CodeFragment> scan(String sourceCode) {
+        logger.debug("开始扫描CHTL源代码，长度: {} 字符", sourceCode.length());
+        List<CodeFragment> fragments = new ArrayList<>();
+        
+        // 创建源代码的可变副本
+        StringBuilder mutableSource = new StringBuilder(sourceCode);
+        
+        // 1. 提取全局样式块
+        extractGlobalStyles(mutableSource, fragments);
+        
+        // 2. 提取script块（包括局部script）
+        extractScriptBlocks(mutableSource, fragments);
+        
+        // 3. 提取局部style块
+        extractLocalStyles(mutableSource, fragments);
+        
+        // 4. 剩余的都是CHTL主体代码
+        String remainingCode = mutableSource.toString().trim();
+        if (!remainingCode.isEmpty()) {
+            fragments.add(new CodeFragment(FragmentType.CHTL, remainingCode, 0));
+        }
+        
+        logger.info("扫描完成，共生成 {} 个代码片段", fragments.size());
+        return fragments;
+    }
+    
+    /**
+     * 提取全局样式块
+     */
+    private void extractGlobalStyles(StringBuilder source, List<CodeFragment> fragments) {
+        Matcher matcher = GLOBAL_STYLE_PATTERN.matcher(source);
+        int offset = 0;
+        
+        while (matcher.find()) {
+            String styleContent = matcher.group(1);
+            int startPos = matcher.start() - offset;
+            
+            fragments.add(new CodeFragment(
+                FragmentType.CSS, 
+                styleContent.trim(), 
+                startPos
+            ));
+            
+            // 从源代码中移除已提取的部分
+            source.delete(startPos, matcher.end() - offset);
+            offset += matcher.end() - matcher.start();
+            
+            logger.debug("提取全局样式块，位置: {}", startPos);
+        }
+    }
+    
+    /**
+     * 提取脚本块
+     */
+    private void extractScriptBlocks(StringBuilder source, List<CodeFragment> fragments) {
+        Matcher matcher = SCRIPT_BLOCK_PATTERN.matcher(source);
+        int offset = 0;
+        
+        while (matcher.find()) {
+            String scriptContent = matcher.group(1);
+            int startPos = matcher.start() - offset;
+            
+            // 判断是否包含CHTL JS特有语法
+            FragmentType type = containsCHTLJSSyntax(scriptContent) 
+                ? FragmentType.CHTL_JS 
+                : FragmentType.JAVASCRIPT;
+            
+            fragments.add(new CodeFragment(
+                type, 
+                scriptContent.trim(), 
+                startPos
+            ));
+            
+            // 从源代码中移除已提取的部分
+            source.delete(startPos, matcher.end() - offset);
+            offset += matcher.end() - matcher.start();
+            
+            logger.debug("提取{}块，位置: {}", type, startPos);
+        }
+    }
+    
+    /**
+     * 提取局部样式块
+     */
+    private void extractLocalStyles(StringBuilder source, List<CodeFragment> fragments) {
+        Matcher matcher = STYLE_BLOCK_PATTERN.matcher(source);
+        int offset = 0;
+        
+        while (matcher.find()) {
+            String styleContent = matcher.group(1);
+            int startPos = matcher.start() - offset;
+            
+            // 局部样式块由CHTL编译器处理
+            fragments.add(new CodeFragment(
+                FragmentType.CHTL_LOCAL_STYLE, 
+                styleContent.trim(), 
+                startPos
+            ));
+            
+            // 保留style块的标记，但清空内容
+            String replacement = "style { /*processed*/ }";
+            source.replace(startPos, matcher.end() - offset, replacement);
+            offset += (matcher.end() - matcher.start()) - replacement.length();
+            
+            logger.debug("提取局部样式块，位置: {}", startPos);
+        }
+    }
+    
+    /**
+     * 检查是否包含CHTL JS特有语法
+     */
+    private boolean containsCHTLJSSyntax(String scriptContent) {
+        // 检查增强选择器 {{}}
+        if (scriptContent.contains("{{") && scriptContent.contains("}}")) {
+            return true;
+        }
+        
+        // 检查箭头操作符 ->
+        if (scriptContent.contains("->")) {
+            return true;
+        }
+        
+        // 检查特殊方法调用
+        if (scriptContent.contains("->listen(") || 
+            scriptContent.contains("->delegate(") ||
+            scriptContent.contains("animate(")) {
+            return true;
+        }
+        
+        return false;
+    }
+    
+    /**
+     * 移除注释（保留--注释）
+     */
+    private String removeComments(String code) {
+        // 保留--注释，移除//和/**/注释
+        return code.replaceAll("(?<!-)//(?!-).*?$", "")
+                   .replaceAll("/\\*(?!\\*/).*?\\*/", "");
+    }
+}

--- a/src/main/java/com/chtl/scanner/CHTLUnifiedScanner.java
+++ b/src/main/java/com/chtl/scanner/CHTLUnifiedScanner.java
@@ -5,186 +5,770 @@ import com.chtl.model.FragmentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
  * CHTL统一扫描器 - 精准代码切割器
- * 负责将CHTL源代码切割成不同类型的片段
+ * 使用宽判严判机制，将代码切割成最小可编译单元
+ * 
+ * 切割策略：
+ * 1. 宽判：JS和CSS代码块作为整体，以CHTL/CHTL JS特征为分割点
+ * 2. 严判：CHTL和CHTL JS代码以最小单元切割，但保持上下文连续性
  */
 public class CHTLUnifiedScanner {
     private static final Logger logger = LoggerFactory.getLogger(CHTLUnifiedScanner.class);
     
-    // 正则表达式模式
-    private static final Pattern STYLE_BLOCK_PATTERN = Pattern.compile(
-        "style\\s*\\{([^{}]*(?:\\{[^{}]*\\}[^{}]*)*)\\}", 
-        Pattern.DOTALL | Pattern.MULTILINE
-    );
+    // CHTL JS特征模式
+    private static final Pattern CHTL_JS_SELECTOR = Pattern.compile("\\{\\{([^}]+)\\}\\}");
+    private static final Pattern CHTL_JS_ARROW = Pattern.compile("->\\s*\\w+");
+    private static final Pattern CHTL_JS_METHODS = Pattern.compile("->\\s*(listen|delegate|animate)\\s*\\(");
     
-    private static final Pattern SCRIPT_BLOCK_PATTERN = Pattern.compile(
-        "script\\s*\\{([^{}]*(?:\\{[^{}]*\\}[^{}]*)*)\\}", 
-        Pattern.DOTALL | Pattern.MULTILINE
-    );
+    // CHTL特征模式
+    private static final Pattern CHTL_ELEMENT = Pattern.compile("\\b\\w+\\s*\\{");
+    private static final Pattern CHTL_ATTRIBUTE = Pattern.compile("\\w+\\s*:\\s*[^;]+;");
+    private static final Pattern CHTL_TEXT = Pattern.compile("\\btext\\s*\\{[^}]*\\}");
+    private static final Pattern CHTL_STYLE = Pattern.compile("\\bstyle\\s*\\{");
+    private static final Pattern CHTL_SCRIPT = Pattern.compile("\\bscript\\s*\\{");
     
-    private static final Pattern GLOBAL_STYLE_PATTERN = Pattern.compile(
-        "\\[Origin\\]\\s*@Style\\s*\\{([^}]*)\\}", 
-        Pattern.DOTALL | Pattern.MULTILINE
-    );
+    // 代码块边界
+    private static final Pattern BLOCK_START = Pattern.compile("\\{");
+    private static final Pattern BLOCK_END = Pattern.compile("\\}");
     
-    private static final Pattern COMMENT_PATTERN = Pattern.compile(
-        "//.*?$|/\\*.*?\\*/", 
-        Pattern.MULTILINE | Pattern.DOTALL
-    );
+    private enum ScanMode {
+        CHTL,           // CHTL主代码
+        LOCAL_STYLE,    // 局部style块
+        LOCAL_SCRIPT,   // 局部script块
+        GLOBAL_STYLE,   // 全局CSS
+        GLOBAL_SCRIPT   // 全局JS
+    }
     
     public CHTLUnifiedScanner() {
-        logger.info("初始化CHTL统一扫描器");
+        logger.info("初始化CHTL统一扫描器 - 宽判严判模式");
     }
     
     /**
      * 扫描并切割CHTL源代码
-     * @param sourceCode CHTL源代码
-     * @return 代码片段列表
      */
     public List<CodeFragment> scan(String sourceCode) {
         logger.debug("开始扫描CHTL源代码，长度: {} 字符", sourceCode.length());
+        
         List<CodeFragment> fragments = new ArrayList<>();
+        ScanContext context = new ScanContext(sourceCode);
         
-        // 创建源代码的可变副本
-        StringBuilder mutableSource = new StringBuilder(sourceCode);
-        
-        // 1. 提取全局样式块
-        extractGlobalStyles(mutableSource, fragments);
-        
-        // 2. 提取script块（包括局部script）
-        extractScriptBlocks(mutableSource, fragments);
-        
-        // 3. 提取局部style块
-        extractLocalStyles(mutableSource, fragments);
-        
-        // 4. 剩余的都是CHTL主体代码
-        String remainingCode = mutableSource.toString().trim();
-        if (!remainingCode.isEmpty()) {
-            fragments.add(new CodeFragment(FragmentType.CHTL, remainingCode, 0));
+        while (!context.isEnd()) {
+            CodeFragment fragment = scanNextFragment(context);
+            if (fragment != null) {
+                fragments.add(fragment);
+                logger.trace("生成片段: {} at {}", fragment.getType(), fragment.getSourcePosition());
+            }
         }
+        
+        // 合并连续的相同类型片段
+        fragments = mergeFragments(fragments);
         
         logger.info("扫描完成，共生成 {} 个代码片段", fragments.size());
         return fragments;
     }
     
     /**
-     * 提取全局样式块
+     * 扫描下一个代码片段
      */
-    private void extractGlobalStyles(StringBuilder source, List<CodeFragment> fragments) {
-        Matcher matcher = GLOBAL_STYLE_PATTERN.matcher(source);
-        int offset = 0;
+    private CodeFragment scanNextFragment(ScanContext context) {
+        context.skipWhitespace();
         
-        while (matcher.find()) {
-            String styleContent = matcher.group(1);
-            int startPos = matcher.start() - offset;
-            
-            fragments.add(new CodeFragment(
-                FragmentType.CSS, 
-                styleContent.trim(), 
-                startPos
-            ));
-            
-            // 从源代码中移除已提取的部分
-            source.delete(startPos, matcher.end() - offset);
-            offset += matcher.end() - matcher.start();
-            
-            logger.debug("提取全局样式块，位置: {}", startPos);
+        if (context.isEnd()) {
+            return null;
+        }
+        
+        // 检测当前位置的代码类型
+        FragmentInfo info = detectFragmentType(context);
+        
+        switch (info.type) {
+            case CHTL:
+                return scanCHTLFragment(context);
+                
+            case CHTL_LOCAL_STYLE:
+                return scanLocalStyleFragment(context);
+                
+            case CHTL_JS:
+                return scanCHTLJSFragment(context);
+                
+            case CSS:
+                return scanCSSFragment(context);
+                
+            case JAVASCRIPT:
+                return scanJavaScriptFragment(context);
+                
+            default:
+                // 未知类型，作为CHTL处理
+                return scanCHTLFragment(context);
         }
     }
     
     /**
-     * 提取脚本块
+     * 检测代码片段类型
      */
-    private void extractScriptBlocks(StringBuilder source, List<CodeFragment> fragments) {
-        Matcher matcher = SCRIPT_BLOCK_PATTERN.matcher(source);
-        int offset = 0;
+    private FragmentInfo detectFragmentType(ScanContext context) {
+        String ahead = context.peekAhead(100);
         
-        while (matcher.find()) {
-            String scriptContent = matcher.group(1);
-            int startPos = matcher.start() - offset;
-            
-            // 判断是否包含CHTL JS特有语法
-            FragmentType type = containsCHTLJSSyntax(scriptContent) 
-                ? FragmentType.CHTL_JS 
-                : FragmentType.JAVASCRIPT;
-            
-            fragments.add(new CodeFragment(
-                type, 
-                scriptContent.trim(), 
-                startPos
-            ));
-            
-            // 从源代码中移除已提取的部分
-            source.delete(startPos, matcher.end() - offset);
-            offset += matcher.end() - matcher.start();
-            
-            logger.debug("提取{}块，位置: {}", type, startPos);
+        // 检查是否在style块内
+        if (context.isInStyleBlock()) {
+            // 检查是否包含CHTL特征
+            if (containsCHTLStyleFeatures(ahead)) {
+                return new FragmentInfo(FragmentType.CHTL_LOCAL_STYLE);
+            }
+            return new FragmentInfo(FragmentType.CSS);
         }
+        
+        // 检查是否在script块内
+        if (context.isInScriptBlock()) {
+            // 检查是否包含CHTL JS特征
+            if (containsCHTLJSFeatures(ahead)) {
+                return new FragmentInfo(FragmentType.CHTL_JS);
+            }
+            return new FragmentInfo(FragmentType.JAVASCRIPT);
+        }
+        
+        // 检查全局样式标记
+        if (ahead.startsWith("[Origin]") && ahead.contains("@Style")) {
+            return new FragmentInfo(FragmentType.CSS);
+        }
+        
+        // 默认为CHTL
+        return new FragmentInfo(FragmentType.CHTL);
     }
     
     /**
-     * 提取局部样式块
+     * 扫描CHTL片段（严判模式）
      */
-    private void extractLocalStyles(StringBuilder source, List<CodeFragment> fragments) {
-        Matcher matcher = STYLE_BLOCK_PATTERN.matcher(source);
-        int offset = 0;
+    private CodeFragment scanCHTLFragment(ScanContext context) {
+        int startPos = context.position;
+        StringBuilder content = new StringBuilder();
         
-        while (matcher.find()) {
-            String styleContent = matcher.group(1);
-            int startPos = matcher.start() - offset;
+        // 扫描CHTL最小单元，但保持连续性
+        while (!context.isEnd()) {
+            // 检查是否遇到style或script块
+            if (context.lookingAt("style\\s*\\{")) {
+                if (content.length() > 0) {
+                    // 返回已收集的CHTL内容
+                    break;
+                }
+                // 处理style块
+                return scanLocalStyleFragment(context);
+            }
             
-            // 局部样式块由CHTL编译器处理
-            fragments.add(new CodeFragment(
-                FragmentType.CHTL_LOCAL_STYLE, 
-                styleContent.trim(), 
-                startPos
-            ));
+            if (context.lookingAt("script\\s*\\{")) {
+                if (content.length() > 0) {
+                    // 返回已收集的CHTL内容
+                    break;
+                }
+                // 处理script块
+                return scanLocalScriptFragment(context);
+            }
             
-            // 保留style块的标记，但清空内容
-            String replacement = "style { /*processed*/ }";
-            source.replace(startPos, matcher.end() - offset, replacement);
-            offset += (matcher.end() - matcher.start()) - replacement.length();
+            // 扫描一个完整的CHTL元素或属性
+            String element = scanCHTLElement(context);
+            if (element != null) {
+                content.append(element);
+                continue;
+            }
             
-            logger.debug("提取局部样式块，位置: {}", startPos);
+            // 扫描单个字符
+            content.append(context.current());
+            context.advance();
+            
+            // 检查是否应该结束当前片段
+            if (shouldEndCHTLFragment(context, content)) {
+                break;
+            }
         }
+        
+        return new CodeFragment(FragmentType.CHTL, content.toString(), startPos);
     }
     
     /**
-     * 检查是否包含CHTL JS特有语法
+     * 扫描CHTL元素
      */
-    private boolean containsCHTLJSSyntax(String scriptContent) {
-        // 检查增强选择器 {{}}
-        if (scriptContent.contains("{{") && scriptContent.contains("}}")) {
-            return true;
+    private String scanCHTLElement(ScanContext context) {
+        // 匹配元素模式: identifier { ... }
+        if (context.lookingAt("\\w+\\s*\\{")) {
+            return scanBlock(context);
         }
         
-        // 检查箭头操作符 ->
-        if (scriptContent.contains("->")) {
-            return true;
+        // 匹配属性模式: identifier : value ;
+        if (context.lookingAt("\\w+\\s*:")) {
+            return scanAttribute(context);
         }
         
-        // 检查特殊方法调用
-        if (scriptContent.contains("->listen(") || 
-            scriptContent.contains("->delegate(") ||
-            scriptContent.contains("animate(")) {
-            return true;
+        return null;
+    }
+    
+    /**
+     * 扫描局部样式片段（严判模式）
+     */
+    private CodeFragment scanLocalStyleFragment(ScanContext context) {
+        int startPos = context.position;
+        
+        // 跳过 style {
+        context.skipPattern("style\\s*\\{");
+        
+        List<CodeFragment> styleFragments = new ArrayList<>();
+        int braceCount = 1;
+        
+        while (!context.isEnd() && braceCount > 0) {
+            if (context.current() == '{') {
+                braceCount++;
+            } else if (context.current() == '}') {
+                braceCount--;
+                if (braceCount == 0) {
+                    context.advance(); // 跳过结束的 }
+                    break;
+                }
+            }
+            
+            // 检测CHTL样式特征
+            if (containsCHTLStyleFeatures(context.peekAhead(50))) {
+                // 切割CHTL样式片段
+                CodeFragment chtlStyle = scanCHTLStyleFragment(context);
+                styleFragments.add(chtlStyle);
+            } else {
+                // 普通CSS片段
+                CodeFragment css = scanPureCSSFragment(context, braceCount);
+                styleFragments.add(css);
+            }
+        }
+        
+        // 合并样式片段
+        return mergeStyleFragments(styleFragments, startPos);
+    }
+    
+    /**
+     * 扫描局部脚本片段
+     */
+    private CodeFragment scanLocalScriptFragment(ScanContext context) {
+        int startPos = context.position;
+        
+        // 跳过 script {
+        context.skipPattern("script\\s*\\{");
+        
+        StringBuilder content = new StringBuilder();
+        int braceCount = 1;
+        
+        while (!context.isEnd() && braceCount > 0) {
+            // 检查CHTL JS特征
+            if (CHTL_JS_SELECTOR.matcher(context.peekAhead(20)).find()) {
+                // 提取CHTL JS选择器
+                String selector = extractCHTLJSSelector(context);
+                content.append(selector);
+                continue;
+            }
+            
+            if (context.lookingAt("->")) {
+                // 处理箭头操作符
+                content.append(context.consume(2));
+                continue;
+            }
+            
+            char ch = context.current();
+            content.append(ch);
+            context.advance();
+            
+            if (ch == '{') {
+                braceCount++;
+            } else if (ch == '}') {
+                braceCount--;
+            }
+        }
+        
+        return new CodeFragment(FragmentType.CHTL_JS, content.toString(), startPos);
+    }
+    
+    /**
+     * 扫描CHTL JS片段（严判模式）
+     */
+    private CodeFragment scanCHTLJSFragment(ScanContext context) {
+        int startPos = context.position;
+        StringBuilder content = new StringBuilder();
+        
+        // 扫描最小CHTL JS单元
+        if (context.lookingAt("\\{\\{")) {
+            // 扫描增强选择器
+            content.append(extractCHTLJSSelector(context));
+        } else if (context.lookingAt("->")) {
+            // 扫描箭头操作及其后续
+            content.append(scanArrowOperation(context));
+        } else {
+            // 扫描普通JS直到遇到CHTL JS特征
+            content.append(scanUntilCHTLJSFeature(context));
+        }
+        
+        return new CodeFragment(FragmentType.CHTL_JS, content.toString(), startPos);
+    }
+    
+    /**
+     * 扫描CSS片段（宽判模式）
+     */
+    private CodeFragment scanCSSFragment(ScanContext context) {
+        int startPos = context.position;
+        StringBuilder content = new StringBuilder();
+        
+        // CSS采用宽判，遇到CHTL特征才分割
+        while (!context.isEnd()) {
+            // 检查是否遇到CHTL特征
+            if (containsCHTLFeatures(context.peekAhead(50))) {
+                break;
+            }
+            
+            content.append(context.current());
+            context.advance();
+        }
+        
+        return new CodeFragment(FragmentType.CSS, content.toString(), startPos);
+    }
+    
+    /**
+     * 扫描JavaScript片段（宽判模式）
+     */
+    private CodeFragment scanJavaScriptFragment(ScanContext context) {
+        int startPos = context.position;
+        StringBuilder content = new StringBuilder();
+        
+        // JS采用宽判，遇到CHTL JS特征才分割
+        while (!context.isEnd()) {
+            // 检查是否遇到CHTL JS特征
+            if (containsCHTLJSFeatures(context.peekAhead(50))) {
+                break;
+            }
+            
+            content.append(context.current());
+            context.advance();
+        }
+        
+        return new CodeFragment(FragmentType.JAVASCRIPT, content.toString(), startPos);
+    }
+    
+    /**
+     * 提取CHTL JS选择器
+     */
+    private String extractCHTLJSSelector(ScanContext context) {
+        StringBuilder selector = new StringBuilder();
+        
+        // 消费 {{
+        selector.append(context.consume(2));
+        
+        // 读取到 }}
+        while (!context.isEnd() && !context.lookingAt("\\}\\}")) {
+            selector.append(context.current());
+            context.advance();
+        }
+        
+        // 消费 }}
+        if (context.lookingAt("\\}\\}")) {
+            selector.append(context.consume(2));
+        }
+        
+        return selector.toString();
+    }
+    
+    /**
+     * 扫描箭头操作
+     */
+    private String scanArrowOperation(ScanContext context) {
+        StringBuilder operation = new StringBuilder();
+        
+        // 消费 ->
+        operation.append(context.consume(2));
+        
+        // 跳过空白
+        while (!context.isEnd() && Character.isWhitespace(context.current())) {
+            operation.append(context.current());
+            context.advance();
+        }
+        
+        // 读取方法名
+        while (!context.isEnd() && (Character.isLetterOrDigit(context.current()) || context.current() == '_')) {
+            operation.append(context.current());
+            context.advance();
+        }
+        
+        return operation.toString();
+    }
+    
+    /**
+     * 扫描直到遇到CHTL JS特征
+     */
+    private String scanUntilCHTLJSFeature(ScanContext context) {
+        StringBuilder content = new StringBuilder();
+        
+        while (!context.isEnd()) {
+            if (containsCHTLJSFeatures(context.peekAhead(20))) {
+                break;
+            }
+            
+            content.append(context.current());
+            context.advance();
+        }
+        
+        return content.toString();
+    }
+    
+    /**
+     * 扫描代码块
+     */
+    private String scanBlock(ScanContext context) {
+        StringBuilder block = new StringBuilder();
+        int braceCount = 0;
+        
+        // 读取标识符
+        while (!context.isEnd() && (Character.isLetterOrDigit(context.current()) || context.current() == '_')) {
+            block.append(context.current());
+            context.advance();
+        }
+        
+        // 跳过空白
+        while (!context.isEnd() && Character.isWhitespace(context.current())) {
+            block.append(context.current());
+            context.advance();
+        }
+        
+        // 读取块内容
+        if (context.current() == '{') {
+            do {
+                block.append(context.current());
+                if (context.current() == '{') {
+                    braceCount++;
+                } else if (context.current() == '}') {
+                    braceCount--;
+                }
+                context.advance();
+            } while (!context.isEnd() && braceCount > 0);
+        }
+        
+        return block.toString();
+    }
+    
+    /**
+     * 扫描属性
+     */
+    private String scanAttribute(ScanContext context) {
+        StringBuilder attr = new StringBuilder();
+        
+        // 读取到分号
+        while (!context.isEnd() && context.current() != ';') {
+            attr.append(context.current());
+            context.advance();
+        }
+        
+        // 包含分号
+        if (context.current() == ';') {
+            attr.append(context.current());
+            context.advance();
+        }
+        
+        return attr.toString();
+    }
+    
+    /**
+     * 检查是否包含CHTL特征
+     */
+    private boolean containsCHTLFeatures(String code) {
+        return CHTL_ELEMENT.matcher(code).find() ||
+               CHTL_ATTRIBUTE.matcher(code).find() ||
+               CHTL_TEXT.matcher(code).find() ||
+               CHTL_STYLE.matcher(code).find() ||
+               CHTL_SCRIPT.matcher(code).find();
+    }
+    
+    /**
+     * 检查是否包含CHTL样式特征
+     */
+    private boolean containsCHTLStyleFeatures(String code) {
+        return code.contains("&") || // 上下文选择器
+               code.matches(".*\\.\\w+\\s*\\{.*") || // 类选择器
+               code.matches(".*#\\w+\\s*\\{.*"); // ID选择器
+    }
+    
+    /**
+     * 检查是否包含CHTL JS特征
+     */
+    private boolean containsCHTLJSFeatures(String code) {
+        return CHTL_JS_SELECTOR.matcher(code).find() ||
+               CHTL_JS_ARROW.matcher(code).find() ||
+               CHTL_JS_METHODS.matcher(code).find();
+    }
+    
+    /**
+     * 判断是否应该结束CHTL片段
+     */
+    private boolean shouldEndCHTLFragment(ScanContext context, StringBuilder content) {
+        // 如果内容已经足够大，考虑分割
+        if (content.length() > 500) {
+            // 检查是否在一个完整的结构边界
+            String lastChars = content.substring(Math.max(0, content.length() - 10));
+            return lastChars.contains("}") || lastChars.contains(";");
         }
         
         return false;
     }
     
     /**
-     * 移除注释（保留--注释）
+     * 扫描CHTL样式片段
      */
-    private String removeComments(String code) {
-        // 保留--注释，移除//和/**/注释
-        return code.replaceAll("(?<!-)//(?!-).*?$", "")
-                   .replaceAll("/\\*(?!\\*/).*?\\*/", "");
+    private CodeFragment scanCHTLStyleFragment(ScanContext context) {
+        int startPos = context.position;
+        StringBuilder content = new StringBuilder();
+        
+        // 扫描CHTL样式特征
+        while (!context.isEnd() && containsCHTLStyleFeatures(context.peekAhead(50))) {
+            if (context.current() == '&') {
+                // 上下文选择器
+                content.append(scanContextSelector(context));
+            } else if (context.current() == '.' || context.current() == '#') {
+                // 类或ID选择器
+                content.append(scanCSSSelector(context));
+            } else {
+                content.append(context.current());
+                context.advance();
+            }
+            
+            // 检查是否应该结束
+            if (content.toString().contains("}")) {
+                break;
+            }
+        }
+        
+        return new CodeFragment(FragmentType.CHTL_LOCAL_STYLE, content.toString(), startPos);
+    }
+    
+    /**
+     * 扫描纯CSS片段
+     */
+    private CodeFragment scanPureCSSFragment(ScanContext context, int maxBraceCount) {
+        int startPos = context.position;
+        StringBuilder content = new StringBuilder();
+        int braceCount = 0;
+        
+        while (!context.isEnd()) {
+            char ch = context.current();
+            
+            if (ch == '{') {
+                braceCount++;
+            } else if (ch == '}') {
+                if (braceCount == 0) {
+                    // 到达style块的结束
+                    break;
+                }
+                braceCount--;
+            }
+            
+            // 检查是否遇到CHTL特征
+            if (containsCHTLStyleFeatures(context.peekAhead(20))) {
+                break;
+            }
+            
+            content.append(ch);
+            context.advance();
+        }
+        
+        return new CodeFragment(FragmentType.CSS, content.toString(), startPos);
+    }
+    
+    /**
+     * 扫描上下文选择器
+     */
+    private String scanContextSelector(ScanContext context) {
+        StringBuilder selector = new StringBuilder();
+        
+        // 消费 &
+        selector.append(context.current());
+        context.advance();
+        
+        // 读取伪类或伪元素
+        while (!context.isEnd() && (context.current() == ':' || Character.isLetterOrDigit(context.current()) || context.current() == '-')) {
+            selector.append(context.current());
+            context.advance();
+        }
+        
+        return selector.toString();
+    }
+    
+    /**
+     * 扫描CSS选择器
+     */
+    private String scanCSSSelector(ScanContext context) {
+        StringBuilder selector = new StringBuilder();
+        
+        // 消费 . 或 #
+        selector.append(context.current());
+        context.advance();
+        
+        // 读取选择器名称
+        while (!context.isEnd() && (Character.isLetterOrDigit(context.current()) || context.current() == '-' || context.current() == '_')) {
+            selector.append(context.current());
+            context.advance();
+        }
+        
+        return selector.toString();
+    }
+    
+    /**
+     * 合并样式片段
+     */
+    private CodeFragment mergeStyleFragments(List<CodeFragment> fragments, int startPos) {
+        if (fragments.isEmpty()) {
+            return new CodeFragment(FragmentType.CHTL_LOCAL_STYLE, "", startPos);
+        }
+        
+        // 如果只有一个片段，直接返回
+        if (fragments.size() == 1) {
+            return fragments.get(0);
+        }
+        
+        // 合并多个片段
+        StringBuilder merged = new StringBuilder();
+        FragmentType primaryType = FragmentType.CHTL_LOCAL_STYLE;
+        
+        for (CodeFragment fragment : fragments) {
+            merged.append(fragment.getContent());
+            if (fragment.getType() == FragmentType.CHTL_LOCAL_STYLE) {
+                primaryType = FragmentType.CHTL_LOCAL_STYLE;
+            }
+        }
+        
+        return new CodeFragment(primaryType, merged.toString(), startPos);
+    }
+    
+    /**
+     * 合并连续的相同类型片段
+     */
+    private List<CodeFragment> mergeFragments(List<CodeFragment> fragments) {
+        if (fragments.size() <= 1) {
+            return fragments;
+        }
+        
+        List<CodeFragment> merged = new ArrayList<>();
+        CodeFragment current = fragments.get(0);
+        
+        for (int i = 1; i < fragments.size(); i++) {
+            CodeFragment next = fragments.get(i);
+            
+            // 如果类型相同且是JS或CSS，考虑合并
+            if (current.getType() == next.getType() && 
+                (current.getType() == FragmentType.CSS || current.getType() == FragmentType.JAVASCRIPT)) {
+                // 合并
+                current = new CodeFragment(
+                    current.getType(),
+                    current.getContent() + next.getContent(),
+                    current.getSourcePosition()
+                );
+            } else {
+                // 不合并，添加当前片段
+                merged.add(current);
+                current = next;
+            }
+        }
+        
+        merged.add(current);
+        return merged;
+    }
+    
+    /**
+     * 扫描上下文
+     */
+    private static class ScanContext {
+        private final String source;
+        private int position;
+        private int line;
+        private int column;
+        private ScanMode mode;
+        
+        ScanContext(String source) {
+            this.source = source;
+            this.position = 0;
+            this.line = 1;
+            this.column = 1;
+            this.mode = ScanMode.CHTL;
+        }
+        
+        boolean isEnd() {
+            return position >= source.length();
+        }
+        
+        char current() {
+            return position < source.length() ? source.charAt(position) : '\0';
+        }
+        
+        void advance() {
+            if (position < source.length()) {
+                if (source.charAt(position) == '\n') {
+                    line++;
+                    column = 1;
+                } else {
+                    column++;
+                }
+                position++;
+            }
+        }
+        
+        String consume(int count) {
+            StringBuilder result = new StringBuilder();
+            for (int i = 0; i < count && !isEnd(); i++) {
+                result.append(current());
+                advance();
+            }
+            return result.toString();
+        }
+        
+        String peekAhead(int count) {
+            int end = Math.min(position + count, source.length());
+            return source.substring(position, end);
+        }
+        
+        boolean lookingAt(String pattern) {
+            return peekAhead(pattern.length() + 10).matches("^" + pattern + ".*");
+        }
+        
+        void skipWhitespace() {
+            while (!isEnd() && Character.isWhitespace(current())) {
+                advance();
+            }
+        }
+        
+        void skipPattern(String pattern) {
+            if (lookingAt(pattern)) {
+                Pattern p = Pattern.compile("^" + pattern);
+                Matcher m = p.matcher(peekAhead(100));
+                if (m.find()) {
+                    consume(m.end());
+                }
+            }
+        }
+        
+        boolean isInStyleBlock() {
+            return mode == ScanMode.LOCAL_STYLE || mode == ScanMode.GLOBAL_STYLE;
+        }
+        
+        boolean isInScriptBlock() {
+            return mode == ScanMode.LOCAL_SCRIPT || mode == ScanMode.GLOBAL_SCRIPT;
+        }
+    }
+    
+    /**
+     * 片段信息
+     */
+    private static class FragmentInfo {
+        final FragmentType type;
+        final int priority;
+        
+        FragmentInfo(FragmentType type) {
+            this(type, 0);
+        }
+        
+        FragmentInfo(FragmentType type, int priority) {
+            this.type = type;
+            this.priority = priority;
+        }
     }
 }

--- a/src/test/java/com/chtl/CHTLCompilerTest.java
+++ b/src/test/java/com/chtl/CHTLCompilerTest.java
@@ -1,0 +1,140 @@
+package com.chtl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * CHTL编译器测试类
+ */
+public class CHTLCompilerTest {
+    
+    private CHTLCompilerMain compiler;
+    
+    @BeforeEach
+    public void setUp() {
+        compiler = new CHTLCompilerMain();
+    }
+    
+    @AfterEach
+    public void tearDown() {
+        compiler.shutdown();
+    }
+    
+    @Test
+    public void testSimpleCHTLCompilation() {
+        String chtlCode = """
+            html {
+                body {
+                    div {
+                        text {
+                            Hello CHTL!
+                        }
+                    }
+                }
+            }
+            """;
+        
+        String result = compiler.compile(chtlCode);
+        
+        assertNotNull(result);
+        assertTrue(result.contains("<html"));
+        assertTrue(result.contains("<body>"));
+        assertTrue(result.contains("<div>"));
+        assertTrue(result.contains("Hello CHTL!"));
+    }
+    
+    @Test
+    public void testLocalStyleCompilation() {
+        String chtlCode = """
+            div {
+                style {
+                    width: 100px;
+                    height: 100px;
+                    background-color: red;
+                }
+                
+                text {
+                    测试内容
+                }
+            }
+            """;
+        
+        String result = compiler.compile(chtlCode);
+        
+        assertNotNull(result);
+        assertTrue(result.contains("style="));
+        assertTrue(result.contains("width: 100px"));
+        assertTrue(result.contains("测试内容"));
+    }
+    
+    @Test
+    public void testCHTLJSCompilation() {
+        String chtlCode = """
+            button {
+                id: testBtn;
+                
+                text {
+                    点击
+                }
+                
+                script {
+                    {{#testBtn}}->listen({
+                        click: () => {
+                            console.log('按钮被点击');
+                        }
+                    });
+                }
+            }
+            """;
+        
+        String result = compiler.compile(chtlCode);
+        
+        assertNotNull(result);
+        assertTrue(result.contains("id=\"testBtn\""));
+        assertTrue(result.contains("_chtl"));
+        assertTrue(result.contains("addEventListener"));
+    }
+    
+    @Test
+    public void testFileCompilation() throws IOException {
+        // 创建临时输入文件
+        Path inputPath = Paths.get("target/test-input.chtl");
+        Path outputPath = Paths.get("target/test-output.html");
+        
+        String chtlContent = """
+            html {
+                head {
+                    title: "测试页面";
+                }
+                body {
+                    h1 {
+                        text { CHTL编译器测试 }
+                    }
+                }
+            }
+            """;
+        
+        Files.writeString(inputPath, chtlContent);
+        
+        // 编译文件
+        compiler.compileFile(inputPath.toString(), outputPath.toString());
+        
+        // 验证输出文件
+        assertTrue(Files.exists(outputPath));
+        String output = Files.readString(outputPath);
+        assertTrue(output.contains("<title>测试页面</title>"));
+        assertTrue(output.contains("<h1>"));
+        assertTrue(output.contains("CHTL编译器测试"));
+        
+        // 清理
+        Files.deleteIfExists(inputPath);
+        Files.deleteIfExists(outputPath);
+    }
+}

--- a/src/test/java/com/chtl/scanner/CHTLUnifiedScannerTest.java
+++ b/src/test/java/com/chtl/scanner/CHTLUnifiedScannerTest.java
@@ -1,0 +1,249 @@
+package com.chtl.scanner;
+
+import com.chtl.model.CodeFragment;
+import com.chtl.model.FragmentType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+/**
+ * CHTL统一扫描器测试
+ * 验证宽判严判机制的正确性
+ */
+public class CHTLUnifiedScannerTest {
+    
+    private CHTLUnifiedScanner scanner;
+    
+    @BeforeEach
+    public void setUp() {
+        scanner = new CHTLUnifiedScanner();
+    }
+    
+    @Test
+    public void testStrictModeForCHTL() {
+        // 测试CHTL严判模式：最小单元切割
+        String code = """
+            div {
+                id: myDiv;
+                class: container;
+            }
+            span {
+                text { Hello }
+            }
+            """;
+        
+        List<CodeFragment> fragments = scanner.scan(code);
+        
+        // CHTL代码应该保持连续，不会过度切割
+        assertTrue(fragments.size() >= 1);
+        assertEquals(FragmentType.CHTL, fragments.get(0).getType());
+    }
+    
+    @Test
+    public void testStrictModeForCHTLJS() {
+        // 测试CHTL JS严判模式：精确切割特征
+        String code = """
+            script {
+                {{#button}}->listen({
+                    click: () => {
+                        console.log('clicked');
+                        {{.box}}->style.color = 'red';
+                    }
+                });
+            }
+            """;
+        
+        List<CodeFragment> fragments = scanner.scan(code);
+        
+        // 应该识别出CHTL JS片段
+        boolean hasCHTLJS = fragments.stream()
+            .anyMatch(f -> f.getType() == FragmentType.CHTL_JS);
+        assertTrue(hasCHTLJS);
+        
+        // 验证CHTL JS特征被正确识别
+        String jsContent = fragments.stream()
+            .filter(f -> f.getType() == FragmentType.CHTL_JS)
+            .map(CodeFragment::getContent)
+            .findFirst()
+            .orElse("");
+        
+        assertTrue(jsContent.contains("{{#button}}"));
+        assertTrue(jsContent.contains("->listen"));
+        assertTrue(jsContent.contains("{{.box}}"));
+    }
+    
+    @Test
+    public void testRelaxedModeForCSS() {
+        // 测试CSS宽判模式：整体处理直到遇到CHTL特征
+        String code = """
+            [Origin] @Style {
+                body {
+                    margin: 0;
+                    padding: 0;
+                }
+                .container {
+                    width: 100%;
+                }
+            }
+            """;
+        
+        List<CodeFragment> fragments = scanner.scan(code);
+        
+        // CSS应该作为一个整体片段
+        assertEquals(1, fragments.size());
+        assertEquals(FragmentType.CSS, fragments.get(0).getType());
+    }
+    
+    @Test
+    public void testRelaxedModeForJS() {
+        // 测试JS宽判模式：整体处理直到遇到CHTL JS特征
+        String code = """
+            script {
+                function normalFunction() {
+                    console.log('This is normal JS');
+                    return true;
+                }
+                
+                const value = 42;
+            }
+            """;
+        
+        List<CodeFragment> fragments = scanner.scan(code);
+        
+        // 普通JS应该作为一个整体片段
+        boolean hasPlainJS = fragments.stream()
+            .anyMatch(f -> f.getType() == FragmentType.JAVASCRIPT);
+        assertTrue(hasPlainJS);
+    }
+    
+    @Test
+    public void testMixedCHTLAndCHTLJS() {
+        // 测试混合CHTL和CHTL JS的切割
+        String code = """
+            div {
+                style {
+                    .box {
+                        color: red;
+                    }
+                    &:hover {
+                        color: blue;
+                    }
+                }
+                
+                script {
+                    {{.box}}->addEventListener('click', () => {
+                        console.log('Box clicked');
+                    });
+                }
+            }
+            """;
+        
+        List<CodeFragment> fragments = scanner.scan(code);
+        
+        // 应该有多种类型的片段
+        boolean hasCHTL = fragments.stream()
+            .anyMatch(f -> f.getType() == FragmentType.CHTL);
+        boolean hasCHTLStyle = fragments.stream()
+            .anyMatch(f -> f.getType() == FragmentType.CHTL_LOCAL_STYLE);
+        boolean hasCHTLJS = fragments.stream()
+            .anyMatch(f -> f.getType() == FragmentType.CHTL_JS);
+        
+        assertTrue(hasCHTL);
+        assertTrue(hasCHTLStyle);
+        assertTrue(hasCHTLJS);
+    }
+    
+    @Test
+    public void testCHTLJSFeatureSplitting() {
+        // 测试CHTL JS特征的精确切割
+        String jsCode = """
+            const box = {{#myBox}};
+            box->style.color = 'red';
+            {{button[0]}}->listen({
+                click: handleClick
+            });
+            """;
+        
+        // 在script块中的处理
+        String code = "script { " + jsCode + " }";
+        List<CodeFragment> fragments = scanner.scan(code);
+        
+        // 验证CHTL JS特征被正确切割
+        String content = fragments.stream()
+            .filter(f -> f.getType() == FragmentType.CHTL_JS)
+            .map(CodeFragment::getContent)
+            .reduce("", String::concat);
+        
+        // 所有CHTL JS特征都应该被保留
+        assertTrue(content.contains("{{#myBox}}"));
+        assertTrue(content.contains("->style"));
+        assertTrue(content.contains("{{button[0]}}"));
+        assertTrue(content.contains("->listen"));
+    }
+    
+    @Test
+    public void testLocalStyleProcessing() {
+        // 测试局部样式的处理
+        String code = """
+            div {
+                style {
+                    width: 100px;
+                    height: 100px;
+                    
+                    .active {
+                        background: yellow;
+                    }
+                    
+                    &:hover {
+                        transform: scale(1.1);
+                    }
+                }
+            }
+            """;
+        
+        List<CodeFragment> fragments = scanner.scan(code);
+        
+        // 应该同时有CHTL和CHTL样式片段
+        boolean hasCHTL = fragments.stream()
+            .anyMatch(f -> f.getType() == FragmentType.CHTL);
+        boolean hasLocalStyle = fragments.stream()
+            .anyMatch(f -> f.getType() == FragmentType.CHTL_LOCAL_STYLE || 
+                         f.getType() == FragmentType.CSS);
+        
+        assertTrue(hasCHTL);
+        assertTrue(hasLocalStyle);
+    }
+    
+    @Test
+    public void testFragmentBoundaries() {
+        // 测试片段边界的正确性
+        String code = """
+            div {
+                id: container;
+            }
+            
+            [Origin] @Style {
+                body { margin: 0; }
+            }
+            
+            script {
+                {{#container}}->onclick = function() {
+                    alert('clicked');
+                };
+            }
+            """;
+        
+        List<CodeFragment> fragments = scanner.scan(code);
+        
+        // 验证片段数量和类型
+        assertTrue(fragments.size() >= 3, "应该至少有3个片段：CHTL、CSS、CHTL JS");
+        
+        // 验证片段顺序和内容
+        for (CodeFragment fragment : fragments) {
+            assertNotNull(fragment.getContent());
+            assertFalse(fragment.getContent().isEmpty());
+        }
+    }
+}

--- a/src/test/resources/example.chtl
+++ b/src/test/resources/example.chtl
@@ -1,0 +1,106 @@
+// CHTL示例文件
+html {
+    head {
+        title: "CHTL示例页面";
+    }
+    
+    body {
+        // 使用局部样式的div
+        div {
+            id: container;
+            
+            style {
+                .container {
+                    width: 1200px;
+                    margin: 0 auto;
+                    padding: 20px;
+                }
+                
+                &:hover {
+                    background-color: #f0f0f0;
+                }
+            }
+            
+            h1 {
+                style {
+                    color: #333;
+                    font-size: 2em;
+                    margin-bottom: 20px;
+                }
+                
+                text {
+                    欢迎使用CHTL！
+                }
+            }
+            
+            div {
+                class: box;
+                
+                style {
+                    .box {
+                        background-color: white;
+                        border: 1px solid #ddd;
+                        border-radius: 8px;
+                        padding: 20px;
+                        margin-bottom: 20px;
+                        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+                    }
+                    
+                    &:hover {
+                        box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+                    }
+                }
+                
+                text {
+                    这是一个使用CHTL创建的示例页面。
+                }
+            }
+            
+            // 带有脚本的按钮
+            button {
+                id: myButton;
+                
+                style {
+                    padding: 10px 20px;
+                    background-color: #007bff;
+                    color: white;
+                    border: none;
+                    border-radius: 4px;
+                    cursor: pointer;
+                    
+                    &:hover {
+                        background-color: #0056b3;
+                    }
+                }
+                
+                text {
+                    点击我
+                }
+                
+                script {
+                    {{#myButton}}->listen({
+                        click: () => {
+                            alert('你点击了按钮！');
+                            {{.box}}->style.backgroundColor = '#f8f9fa';
+                        }
+                    });
+                }
+            }
+        }
+        
+        // 全局样式
+        [Origin] @Style {
+            body {
+                font-family: Arial, sans-serif;
+                background-color: #f5f5f5;
+                margin: 0;
+                padding: 0;
+            }
+        }
+        
+        // 全局脚本
+        script {
+            console.log('CHTL页面已加载');
+        }
+    }
+}


### PR DESCRIPTION
Implement the CHTL compiler system with a refined scanner.

The scanner now uses a "wide-judgment, strict-judgment" mechanism to precisely segment CHTL and CHTL JS code into minimal, context-aware units, while treating CSS and JavaScript code broadly. This ensures that downstream compilers receive appropriate code blocks without needing to handle CHTL-specific features.

---
<a href="https://cursor.com/background-agent?bcId=bc-4d0f7697-8fa4-4189-8c3a-8cf13c7de734">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4d0f7697-8fa4-4189-8c3a-8cf13c7de734">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

